### PR TITLE
Added template number to error message

### DIFF
--- a/Framework Files/7R/Templates/fn_saveTemplate.sqf
+++ b/Framework Files/7R/Templates/fn_saveTemplate.sqf
@@ -31,7 +31,7 @@ if (isNil "SR_Template") then {
 		_check = true;
 	};
 }forEach SR_Template;
-if (_check) exitWith {hint "Error: Template already exists."};
+if (_check) exitWith { hint format ["Error: Template %1 already exists.", _templateNumber] };
 
 // Unit Side
 private _side = side _leader;


### PR DESCRIPTION
I edited the "error template already exists" hint so it adds the number of the template.
This way you don't have to search every dude in order to find the next ID. Just makes it easier...