### PR TITLE
Fixed error in Zen_OccupyHouse

### DIFF
--- a/Framework Files/scripts/Zen_OccupyHouse.sqf
+++ b/Framework Files/scripts/Zen_OccupyHouse.sqf
@@ -11,7 +11,7 @@
 		Legacy Compatibility
 */
 // Parameter Init
-params ["_position","_units","_radius"];,
+params ["_position","_units","_radius"];
 
 // New Function
 [_position,_units,_radius] spawn fw_fnc_garrison;


### PR DESCRIPTION
Zen_OccupyHouse gave an error when spawning civilians, caused by the misplaced comma (`,`) in the file.