### PR TITLE
1006 Missing semicolon after init condition in shared functions

### DIFF
--- a/Framework Files/7R/Shared/functions.hpp
+++ b/Framework Files/7R/Shared/functions.hpp
@@ -117,8 +117,8 @@
 	class AiPatrol {
 		file = "7R\AI\PatrolModule";
 		class patrol{};
-		class patrolInit{preInit = true};
-		class patrolLoop{postInit = true};
+		class patrolInit{preInit = 1;};
+		class patrolLoop{postInit = 1;};
 	};
 	class AiCommon {
 		file = "7R\AI\Common";

--- a/Framework Files/initPlayerLocal.sqf
+++ b/Framework Files/initPlayerLocal.sqf
@@ -78,7 +78,7 @@ _ACA5 = ["7R_Artillery","5 Rounds","",{null = ["ArtilleryTarget","",5,50,10] spa
 [(typeOf player), 1, ["ACE_SelfActions", "7R_Header","7R_ArtyH", "7R_ArtilleryHeader"], _ACA5] call ace_interact_menu_fnc_addActionToClass;
 _ACA7 = ["7R_Artillery","7 Rounds","",{null = ["ArtilleryTarget","",7,75,10] spawn fw_fnc_artillery},_isLeader] call ace_interact_menu_fnc_createAction;
 [(typeOf player), 1, ["ACE_SelfActions", "7R_Header","7R_ArtyH", "7R_ArtilleryHeader"], _ACA7] call ace_interact_menu_fnc_addActionToClass;
-_ACAS = ["7R_Artillery","Smoke Barage","",{null = ["ArtilleryTarget","UK3CB_BAF_Smoke_60mm_AMOS",7,100,10,1] spawn fw_fnc_artillery},_isLeader] call ace_interact_menu_fnc_createAction;
+_ACAS = ["7R_Artillery","Smoke Barrage","",{null = ["ArtilleryTarget","UK3CB_BAF_Smoke_60mm_AMOS",7,100,10,1] spawn fw_fnc_artillery},_isLeader] call ace_interact_menu_fnc_createAction;
 [(typeOf player), 1, ["ACE_SelfActions", "7R_Header","7R_ArtyH", "7R_ArtilleryHeader"], _ACAS] call ace_interact_menu_fnc_addActionToClass;
 
 // CAS


### PR DESCRIPTION
In Shared/function.hpp, in PatrolModule inserted missing semicolons after init conditions. Rewritten condition for consistency.