### PR TITLE
Fix to BAF PLT engineer

### DIFF
--- a/loadouts/T2_BAF_Royal Marines_MC/baf_p_e_rep.sqf
+++ b/loadouts/T2_BAF_Royal Marines_MC/baf_p_e_rep.sqf
@@ -25,7 +25,6 @@ _unit addVest "UK3CB_BAF_V_Osprey_SL_A";
 for "_i" from 1 to 3 do {_unit addItemToVest "SmokeShell";};
 for "_i" from 1 to 2 do {_unit addItemToVest "SmokeShellYellow";};
 _unit addBackpack "UK3CB_BAF_B_Bergen_MTP_Engineer_H_A";
-for "_i" from 1 to 3 do {this addItemToBackpack "ACE_";
 for "_i" from 1 to 3 do {_unit addItemToBackpack "ACE_CableTie";};
 _unit addItemToBackpack "ToolKit";
 _unit addItemToBackpack "ACE_EntrenchingTool";


### PR DESCRIPTION
Line 28 contained an error. 
"for "_i" from 1 to 3 do {_unit addItemToBackpack "ACE_";" Which doesn't add nothing and doesn't allow the page to give the rest of the loadout including weapons. 

Line 28 has now been removed.