### PR TITLE
Update description.ext

### DIFF
--- a/Framework Files/description.ext
+++ b/Framework Files/description.ext
@@ -60,10 +60,6 @@ class CfgRemoteExec
 			allowedTargets = 0;
 			jip = 1;
 		};
-		class fw_fnc_exfilAction {
-			allowedTargets = 0;
-			jip = 1;
-		};
 	};
 	class Commands
 	{


### PR DESCRIPTION
class fw_fnc_exfilAction defined twice, gives a error on mission launch.