### PR TITLE
Fixed syntax error in fn_surrender

### DIFF
--- a/Framework Files/7R/AI/Common/fn_surrender.sqf
+++ b/Framework Files/7R/AI/Common/fn_surrender.sqf
@@ -1,13 +1,13 @@
 /*
 	Parameters:
 		<-- Unit as Object
-	
+
 	Return:
 	--> None
-		
+
 	Description:
 		Makes a Unit surrender, stops surrendering if not enemies are close or too much time passed
-		
+
 	Example:
 		[_unit] spawn fw_fnc_surrender;
 */
@@ -18,6 +18,15 @@ params ["_unit"];
 [_unit, true] call ace_captives_setSurrendered;
 
 // If unit is handcuffed do nothing, else unsurrender after timer and continue fighting
-[{{_this getVariable ["ace_captives_isHandcuffed", false]}, {}, _unit, random [30,45,60], {
-	[_this, false] call ace_captives_setSurrendered;
-}] call CBA_fnc_waitUntilAndExecute;
+[
+	// Condition
+	{_this getVariable ["ace_captives_isHandcuffed", false]},
+	// Statement
+	{},
+	// Args
+	_unit,
+	// Timeout
+	random [30, 45, 60],
+	// TimeoutCode
+	{[_this, false] call ace_captives_setSurrendered;}
+] call CBA_fnc_waitUntilAndExecute;


### PR DESCRIPTION
Some braces were misplaced. Added comments to the function as well.