### PR TITLE
Fixed wrongly named function call

### DIFF
--- a/loadouts/T2_US_Rangers_Retro_D/BigBox.txt
+++ b/loadouts/T2_US_Rangers_Retro_D/BigBox.txt
@@ -1,16 +1,16 @@
-if(isServer) then {  
-clearweaponcargoGlobal this;  
-clearmagazinecargoGlobal this;  
-clearitemcargoGlobal this; 
-clearBackpackCargoGlobal this; 
-this addmagazinecargoGlobal ["rhs_200rnd_556x45_M_SAW", 40];    
-this addmagazinecargoGlobal ["rhsusf_100Rnd_556x45_soft_pouch", 40];  
-this addmagazinecargoGlobal ["rhsusf_100Rnd_762x51", 40];  
-this addmagazinecargoGlobal ["MRAWS_HEAT_F", 10];  
+if(isServer) then {
+clearweaponcargoGlobal this;
+clearmagazinecargoGlobal this;
+clearitemcargoGlobal this;
+clearBackpackCargoGlobal this;
+this addmagazinecargoGlobal ["rhs_200rnd_556x45_M_SAW", 40];
+this addmagazinecargoGlobal ["rhsusf_100Rnd_556x45_soft_pouch", 40];
+this addmagazinecargoGlobal ["rhsusf_100Rnd_762x51", 40];
+this addmagazinecargoGlobal ["MRAWS_HEAT_F", 10];
 this addmagazinecargoGlobal ["MRAWS_HE_F", 10];
 this addWeaponcargoGlobal ["rhs_weap_M136_hedp", 20];
 this addWeaponcargoGlobal ["rhs_weap_m72a7", 10];
-this additemcargoGlobal ["SatchelCharge_Remote_Mag", 6];  
-this additemcargoGlobal ["DemoCharge_Remote_Mag", 12];  
-this addBackpackGargoGlobal ["usm_pack_bandolier_empty", 12];  
+this additemcargoGlobal ["SatchelCharge_Remote_Mag", 6];
+this additemcargoGlobal ["DemoCharge_Remote_Mag", 12];
+this addBackpackCargoGlobal ["usm_pack_bandolier_empty", 12];
 };

--- a/loadouts/T2_US_Rangers_Retro_WL/BigBox.txt
+++ b/loadouts/T2_US_Rangers_Retro_WL/BigBox.txt
@@ -1,16 +1,16 @@
-if(isServer) then {  
-clearweaponcargoGlobal this;  
-clearmagazinecargoGlobal this;  
-clearitemcargoGlobal this; 
-clearBackpackCargoGlobal this; 
-this addmagazinecargoGlobal ["rhs_200rnd_556x45_M_SAW", 40];    
-this addmagazinecargoGlobal ["rhsusf_100Rnd_556x45_soft_pouch", 40];  
-this addmagazinecargoGlobal ["rhsusf_100Rnd_762x51", 40];  
-this addmagazinecargoGlobal ["MRAWS_HEAT_F", 10];  
+if(isServer) then {
+clearweaponcargoGlobal this;
+clearmagazinecargoGlobal this;
+clearitemcargoGlobal this;
+clearBackpackCargoGlobal this;
+this addmagazinecargoGlobal ["rhs_200rnd_556x45_M_SAW", 40];
+this addmagazinecargoGlobal ["rhsusf_100Rnd_556x45_soft_pouch", 40];
+this addmagazinecargoGlobal ["rhsusf_100Rnd_762x51", 40];
+this addmagazinecargoGlobal ["MRAWS_HEAT_F", 10];
 this addmagazinecargoGlobal ["MRAWS_HE_F", 10];
 this addWeaponcargoGlobal ["rhs_weap_M136_hedp", 20];
 this addWeaponcargoGlobal ["rhs_weap_m72a7", 10];
-this additemcargoGlobal ["SatchelCharge_Remote_Mag", 6];  
-this additemcargoGlobal ["DemoCharge_Remote_Mag", 12];  
-this addBackpackGargoGlobal ["usm_pack_bandolier_empty", 12];  
+this additemcargoGlobal ["SatchelCharge_Remote_Mag", 6];
+this additemcargoGlobal ["DemoCharge_Remote_Mag", 12];
+this addBackpackCargoGlobal ["usm_pack_bandolier_empty", 12];
 };

--- a/loadouts/T3_US_Army_Retro_D/BigBox.txt
+++ b/loadouts/T3_US_Army_Retro_D/BigBox.txt
@@ -1,16 +1,16 @@
-if(isServer) then {  
-clearweaponcargoGlobal this;  
-clearmagazinecargoGlobal this;  
-clearitemcargoGlobal this; 
-clearBackpackCargoGlobal this; 
-this addmagazinecargoGlobal ["rhs_200rnd_556x45_M_SAW", 40];    
-this addmagazinecargoGlobal ["rhsusf_100Rnd_556x45_soft_pouch", 40];  
-this addmagazinecargoGlobal ["rhsusf_100Rnd_762x51", 40];  
-this addmagazinecargoGlobal ["MRAWS_HEAT_F", 10];  
+if(isServer) then {
+clearweaponcargoGlobal this;
+clearmagazinecargoGlobal this;
+clearitemcargoGlobal this;
+clearBackpackCargoGlobal this;
+this addmagazinecargoGlobal ["rhs_200rnd_556x45_M_SAW", 40];
+this addmagazinecargoGlobal ["rhsusf_100Rnd_556x45_soft_pouch", 40];
+this addmagazinecargoGlobal ["rhsusf_100Rnd_762x51", 40];
+this addmagazinecargoGlobal ["MRAWS_HEAT_F", 10];
 this addmagazinecargoGlobal ["MRAWS_HE_F", 10];
 this addWeaponcargoGlobal ["rhs_weap_M136_hedp", 20];
 this addWeaponcargoGlobal ["rhs_weap_m72a7", 10];
-this additemcargoGlobal ["SatchelCharge_Remote_Mag", 6];  
-this additemcargoGlobal ["DemoCharge_Remote_Mag", 12];  
-this addBackpackGargoGlobal ["usm_pack_bandolier_empty", 12];  
+this additemcargoGlobal ["SatchelCharge_Remote_Mag", 6];
+this additemcargoGlobal ["DemoCharge_Remote_Mag", 12];
+this addBackpackCargoGlobal ["usm_pack_bandolier_empty", 12];
 };

--- a/loadouts/T3_US_Army_Retro_WL/BigBox.txt
+++ b/loadouts/T3_US_Army_Retro_WL/BigBox.txt
@@ -1,16 +1,16 @@
-if(isServer) then {  
-clearweaponcargoGlobal this;  
-clearmagazinecargoGlobal this;  
-clearitemcargoGlobal this; 
-clearBackpackCargoGlobal this; 
-this addmagazinecargoGlobal ["rhs_200rnd_556x45_M_SAW", 40];    
-this addmagazinecargoGlobal ["rhsusf_100Rnd_556x45_soft_pouch", 40];  
-this addmagazinecargoGlobal ["rhsusf_100Rnd_762x51", 40];  
-this addmagazinecargoGlobal ["MRAWS_HEAT_F", 10];  
+if(isServer) then {
+clearweaponcargoGlobal this;
+clearmagazinecargoGlobal this;
+clearitemcargoGlobal this;
+clearBackpackCargoGlobal this;
+this addmagazinecargoGlobal ["rhs_200rnd_556x45_M_SAW", 40];
+this addmagazinecargoGlobal ["rhsusf_100Rnd_556x45_soft_pouch", 40];
+this addmagazinecargoGlobal ["rhsusf_100Rnd_762x51", 40];
+this addmagazinecargoGlobal ["MRAWS_HEAT_F", 10];
 this addmagazinecargoGlobal ["MRAWS_HE_F", 10];
 this addWeaponcargoGlobal ["rhs_weap_M136_hedp", 20];
 this addWeaponcargoGlobal ["rhs_weap_m72a7", 10];
-this additemcargoGlobal ["SatchelCharge_Remote_Mag", 6];  
-this additemcargoGlobal ["DemoCharge_Remote_Mag", 12];  
-this addBackpackGargoGlobal ["usm_pack_bandolier_empty", 12];  
+this additemcargoGlobal ["SatchelCharge_Remote_Mag", 6];
+this additemcargoGlobal ["DemoCharge_Remote_Mag", 12];
+this addBackpackCargoGlobal ["usm_pack_bandolier_empty", 12];
 };


### PR DESCRIPTION
Would cause an error when copy-pasting bigbox.txt for retro loadouts.

My editor (vscode) also auto-trimmed whitespace at the end of a line.