### PR TITLE
Fix syntax error in vehicle drop action script

### DIFF
--- a/Framework Files/7R/Supplies/fn_vehicleDropAction.sqf
+++ b/Framework Files/7R/Supplies/fn_vehicleDropAction.sqf
@@ -35,7 +35,9 @@ private _actions = [];
 	] call ace_interact_menu_fnc_createAction;
 
 	_actions pushBack [_code, [], _vehicle];
+	
+	true
 
-} forEach SR_Vehicle_Drop;
+} count SR_Vehicle_Drop;
 
-_actions;
+_actions


### PR DESCRIPTION
While the script did work, the SQF language checker of VScode reported a number of errors in it.
This update removes those errors but does not touch the script's functionality.