### PR TITLE
Fixed T1 bundeswehr loadouts

### DIFF
--- a/loadouts/T1_Bundeswehr_D/bw_e_ar.sqf
+++ b/loadouts/T1_Bundeswehr_D/bw_e_ar.sqf
@@ -31,7 +31,7 @@ _unit addHeadgear "BWA3_CrewmanKSK_Tropen_Headset";
 _unit addGoggles "shemagh_goggclr_tan";
 
 comment "Add weapons";
-__unit addWeapon "BWA3_MG4";
+_unit addWeapon "BWA3_MG4";
 _unit addPrimaryWeaponItem "BWA3_acc_VarioRay_irlaser";
 _unit addPrimaryWeaponItem "BWA3_optic_ZO4x30_brown";
 _unit addWeapon "RH_usp";
@@ -52,7 +52,7 @@ _unit addItemToUniform "ACRE_PRC343";
 
 if (isNil "SR_Night") then {SR_Night = false};
 if (SR_Night) then {
-	_unit linkItem "rhsusf_ANPVS_15";
+	_unit linkItem "A3_GPNVG18_BLK_F";
 	_unit setUnitTrait ["camouflageCoef",SR_Camo_Coef];
 };
 _unit setVariable ["SR_Class","EAR", true];

--- a/loadouts/T1_Bundeswehr_D/bw_e_d.sqf
+++ b/loadouts/T1_Bundeswehr_D/bw_e_d.sqf
@@ -52,7 +52,7 @@ _unit addItemToUniform "ACRE_PRC343";
 
 if (isNil "SR_Night") then {SR_Night = false};
 if (SR_Night) then {
-	_unit linkItem "rhsusf_ANPVS_15";
+	_unit linkItem "A3_GPNVG18_BLK_F";
 	_unit setUnitTrait ["camouflageCoef",SR_Camo_Coef];
 };
 _unit setVariable ["SR_Class","ED", true];

--- a/loadouts/T1_Bundeswehr_D/bw_e_e_demo.sqf
+++ b/loadouts/T1_Bundeswehr_D/bw_e_e_demo.sqf
@@ -28,7 +28,6 @@ _unit addBackpack "BWA3_Kitbag_Tropen";
 for "_i" from 1 to 3 do {_unit addItemToBackpack "ACE_CableTie";};
 _unit addItemToBackpack "ACE_Clacker";
 _unit addItemToBackpack "ACE_EntrenchingTool";
-_unit addItemToBackpack "ACE_SpraypaintGreen";
 for "_i" from 1 to 2 do {_unit addItemToBackpack "SatchelCharge_Remote_Mag";};
 for "_i" from 1 to 2 do {_unit addItemToBackpack "DemoCharge_Remote_Mag";};
 _unit addHeadgear "BWA3_CrewmanKSK_Tropen_Headset";
@@ -55,7 +54,7 @@ _unit addItemToUniform "ACRE_PRC343";
 
 if (isNil "SR_Night") then {SR_Night = false};
 if (SR_Night) then {
-	_unit linkItem "rhsusf_ANPVS_15";
+	_unit linkItem "A3_GPNVG18_BLK_F";
 	_unit setUnitTrait ["camouflageCoef",SR_Camo_Coef];
 };
 _unit setVariable ["SR_Class","EE", true];

--- a/loadouts/T1_Bundeswehr_D/bw_e_e_eod.sqf
+++ b/loadouts/T1_Bundeswehr_D/bw_e_e_eod.sqf
@@ -26,11 +26,10 @@ for "_i" from 1 to 3 do {_unit addItemToVest "BWA3_DM25";};
 for "_i" from 1 to 2 do {_unit addItemToVest "BWA3_DM32_Purple";};
 _unit addBackpack "BWA3_Kitbag_Tropen";
 for "_i" from 1 to 3 do {_unit addItemToBackpack "ACE_CableTie";};
-unit addItemToBackpack "ACE_DefusalKit";
+_unit addItemToBackpack "ACE_DefusalKit";
 _unit addItemToBackpack "MineDetector";
 _unit addItemToBackpack "ACE_EntrenchingTool";
 _unit addItemToBackpack "ACE_SpraypaintRed";
-_unit addItemToBackpack "ACE_SpraypaintGreen";
 for "_i" from 1 to 2 do {_unit addItemToBackpack "DemoCharge_Remote_Mag";};
 _unit addHeadgear "BWA3_CrewmanKSK_Tropen_Headset";
 _unit addGoggles "shemagh_loosetanBG";
@@ -56,7 +55,7 @@ _unit addItemToUniform "ACRE_PRC343";
 
 if (isNil "SR_Night") then {SR_Night = false};
 if (SR_Night) then {
-	_unit linkItem "rhsusf_ANPVS_15";
+	_unit linkItem "A3_GPNVG18_BLK_F";
 	_unit setUnitTrait ["camouflageCoef",SR_Camo_Coef];
 };
 _unit setVariable ["SR_Class","EE", true];

--- a/loadouts/T1_Bundeswehr_D/bw_e_e_fort.sqf
+++ b/loadouts/T1_Bundeswehr_D/bw_e_e_fort.sqf
@@ -55,7 +55,7 @@ _unit addItemToUniform "ACRE_PRC343";
 
 if (isNil "SR_Night") then {SR_Night = false};
 if (SR_Night) then {
-	_unit linkItem "rhsusf_ANPVS_15";
+	_unit linkItem "A3_GPNVG18_BLK_F";
 	_unit setUnitTrait ["camouflageCoef",SR_Camo_Coef];
 };
 _unit setVariable ["SR_Class","EE", true];

--- a/loadouts/T1_Bundeswehr_D/bw_e_e_rep.sqf
+++ b/loadouts/T1_Bundeswehr_D/bw_e_e_rep.sqf
@@ -28,7 +28,6 @@ _unit addBackpack "BWA3_Kitbag_Tropen";
 for "_i" from 1 to 3 do {_unit addItemToBackpack "ACE_CableTie";};
 _unit addItemToBackpack "ToolKit";
 _unit addItemToBackpack "ACE_EntrenchingTool";
-_unit addItemToBackpack "ACE_SpraypaintGreen";
 _unit addHeadgear "BWA3_CrewmanKSK_Tropen_Headset";
 _unit addGoggles "shemagh_loosetanBG";
 
@@ -53,7 +52,7 @@ _unit addItemToUniform "ACRE_PRC343";
 
 if (isNil "SR_Night") then {SR_Night = false};
 if (SR_Night) then {
-	_unit linkItem "rhsusf_ANPVS_15";
+	_unit linkItem "A3_GPNVG18_BLK_F";
 	_unit setUnitTrait ["camouflageCoef",SR_Camo_Coef];
 };
 _unit setVariable ["SR_Class","EE", true];

--- a/loadouts/T1_Bundeswehr_D/bw_e_hat.sqf
+++ b/loadouts/T1_Bundeswehr_D/bw_e_hat.sqf
@@ -50,7 +50,7 @@ _unit addItemToUniform "ACRE_PRC343";
 
 if (isNil "SR_Night") then {SR_Night = false};
 if (SR_Night) then {
-	_unit linkItem "rhsusf_ANPVS_15";
+	_unit linkItem "A3_GPNVG18_BLK_F";
 	_unit setUnitTrait ["camouflageCoef",SR_Camo_Coef];
 };
 _unit setVariable ["SR_Class","EH", true];

--- a/loadouts/T1_Bundeswehr_D/bw_e_hat_ab.sqf
+++ b/loadouts/T1_Bundeswehr_D/bw_e_hat_ab.sqf
@@ -51,7 +51,7 @@ _unit addItemToUniform "ACRE_PRC343";
 
 if (isNil "SR_Night") then {SR_Night = false};
 if (SR_Night) then {
-	_unit linkItem "rhsusf_ANPVS_15";
+	_unit linkItem "A3_GPNVG18_BLK_F";
 	_unit setUnitTrait ["camouflageCoef",SR_Camo_Coef];
 };
 _unit setVariable ["SR_Class","EAH", true];

--- a/loadouts/T1_Bundeswehr_D/bw_e_mor.sqf
+++ b/loadouts/T1_Bundeswehr_D/bw_e_mor.sqf
@@ -51,7 +51,7 @@ _unit addItemToUniform "ACRE_PRC343";
 
 if (isNil "SR_Night") then {SR_Night = false};
 if (SR_Night) then {
-	_unit linkItem "rhsusf_ANPVS_15";
+	_unit linkItem "A3_GPNVG18_BLK_F";
 	_unit setUnitTrait ["camouflageCoef",SR_Camo_Coef];
 };
 _unit setVariable ["SR_Class","EH", true];

--- a/loadouts/T1_Bundeswehr_D/bw_e_mor_ab.sqf
+++ b/loadouts/T1_Bundeswehr_D/bw_e_mor_ab.sqf
@@ -54,7 +54,7 @@ _unit addItemToUniform "ACRE_PRC343";
 
 if (isNil "SR_Night") then {SR_Night = false};
 if (SR_Night) then {
-	_unit linkItem "rhsusf_ANPVS_15";
+	_unit linkItem "A3_GPNVG18_BLK_F";
 	_unit setUnitTrait ["camouflageCoef",SR_Camo_Coef];
 };
 _unit setVariable ["SR_Class","EAH", true];

--- a/loadouts/T1_Bundeswehr_D/bw_e_r.sqf
+++ b/loadouts/T1_Bundeswehr_D/bw_e_r.sqf
@@ -50,7 +50,7 @@ _unit addItemToUniform "ACRE_PRC343";
 
 if (isNil "SR_Night") then {SR_Night = false};
 if (SR_Night) then {
-	_unit linkItem "rhsusf_ANPVS_15";
+	_unit linkItem "A3_GPNVG18_BLK_F";
 	_unit setUnitTrait ["camouflageCoef",SR_Camo_Coef];
 };
 _unit setVariable ["SR_Class","ER", true];

--- a/loadouts/T1_Bundeswehr_D/bw_f_com.sqf
+++ b/loadouts/T1_Bundeswehr_D/bw_f_com.sqf
@@ -21,9 +21,9 @@ _unit addItemToUniform "ACE_Flashlight_MX991";
 _unit addItemToUniform "BWA3_DM25";
 _unit addItemToUniform "Chemlight_green";
 _unit addVest "pbw_splitter_zivil";
-for "_i" from 1 to 3 do {_unit addItemToVest "ACE_CableTie";};
+for "_i" from 1 to 3 do {_unit addItemToVest "ACE_CableTie"};
 _unit addItemToVest "BWA3_DM25";
-for"_i" 1 to 2 do {_unit addItemToVest "BWA3_DM32_purple";};
+for "_i" from 1 to 2 do {_unit addItemToVest "BWA3_DM32_purple"};
 _unit addItemToVest "ACE_microDAGR";
 _unit addHeadgear "BWA3_crewmanKSK_headset";
 _unit addGoggles "rhs_googles_clear";
@@ -41,15 +41,15 @@ _unit linkItem "ItemCompass";
 _unit linkItem "ItemWatch";
 _unit linkItem "ItemGPS";
 
-for "_i" from 1 to 4 do {_unit addItemToVest "30Rnd_9x21_Mag";};
+for "_i" from 1 to 4 do {_unit addItemToVest "30Rnd_9x21_Mag"};
 
 _unit addItemToUniform "ACRE_PRC343";
 _unit addItemToVest "ACRE_PRC152";
 
 if (isNil "SR_Night") then {SR_Night = false};
 if (SR_Night) then {
-	_unit linkItem "rhsusf_ANPVS_15";
-	for "_i" from 1 to 2 do {_unit addItemToBackpack "ACE_HandFlare_Green";};
+	_unit linkItem "A3_GPNVG18_BLK_F";
+	for "_i" from 1 to 2 do {_unit addItemToBackpack "ACE_HandFlare_Green"};
 	_unit setUnitTrait ["camouflageCoef",SR_Camo_Coef];
 };
 _unit setVariable ["SR_Class","TC", true];

--- a/loadouts/T1_Bundeswehr_D/bw_f_crew.sqf
+++ b/loadouts/T1_Bundeswehr_D/bw_f_crew.sqf
@@ -48,7 +48,7 @@ _unit addItemToVest "ACRE_PRC152";
 
 if (isNil "SR_Night") then {SR_Night = false};
 if (SR_Night) then {
-	_unit linkItem "rhsusf_ANPVS_15";
+	_unit linkItem "A3_GPNVG18_BLK_F";
 	_unit setUnitTrait ["camouflageCoef",SR_Camo_Coef];
 };
 _unit setVariable ["SR_Class","TC", true];

--- a/loadouts/T1_Bundeswehr_D/bw_f_tech.sqf
+++ b/loadouts/T1_Bundeswehr_D/bw_f_tech.sqf
@@ -47,7 +47,7 @@ _unit addItemToVest "ACRE_PRC152";
 
 if (isNil "SR_Night") then {SR_Night = false};
 if (SR_Night) then {
-	_unit linkItem "rhsusf_ANPVS_15";
+	_unit linkItem "A3_GPNVG18_BLK_F";
 	_unit setUnitTrait ["camouflageCoef",SR_Camo_Coef];
 };
 _unit setVariable ["SR_Class","TC", true];

--- a/loadouts/T1_Bundeswehr_D/bw_medic.sqf
+++ b/loadouts/T1_Bundeswehr_D/bw_medic.sqf
@@ -55,7 +55,7 @@ _unit addItemToUniform "ACRE_PRC343";
 
 if (isNil "SR_Night") then {SR_Night = false};
 if (SR_Night) then {
-	_unit linkItem "rhsusf_ANPVS_15";
+	_unit linkItem "A3_GPNVG18_BLK_F";
 	_unit setUnitTrait ["camouflageCoef",SR_Camo_Coef];
 };
 _unit setVariable ["SR_Class","M", true];

--- a/loadouts/T1_Bundeswehr_D/bw_o_ar.sqf
+++ b/loadouts/T1_Bundeswehr_D/bw_o_ar.sqf
@@ -31,7 +31,7 @@ _unit addHeadgear "milgp_h_airframe_01_RGR";
 _unit addGoggles "shemagh_goggclr_tan";
 
 comment "Add weapons";
-__unit addWeapon "BWA3_MG4";
+_unit addWeapon "BWA3_MG4";
 _unit addPrimaryWeaponItem "BWA3_acc_VarioRay_irlaser";
 _unit addWeapon "RH_usp";
 _unit addHandgunItem "RH_gemtech45";
@@ -51,7 +51,7 @@ _unit addItemToUniform "ACRE_PRC343";
 
 if (isNil "SR_Night") then {SR_Night = false};
 if (SR_Night) then {
-	_unit linkItem "rhsusf_ANPVS_15";
+	_unit linkItem "A3_GPNVG18_BLK_F";
 	_unit setUnitTrait ["camouflageCoef",SR_Camo_Coef];
 };
 _unit setVariable ["SR_Class","AR", true];

--- a/loadouts/T1_Bundeswehr_D/bw_o_br.sqf
+++ b/loadouts/T1_Bundeswehr_D/bw_o_br.sqf
@@ -50,7 +50,7 @@ _unit addItemToUniform "ACRE_PRC343";
 
 if (isNil "SR_Night") then {SR_Night = false};
 if (SR_Night) then {
-	_unit linkItem "rhsusf_ANPVS_15";
+	_unit linkItem "A3_GPNVG18_BLK_F";
 	_unit setUnitTrait ["camouflageCoef",SR_Camo_Coef];
 };
 _unit setVariable ["SR_Class","BR", true];

--- a/loadouts/T1_Bundeswehr_D/bw_o_dmr.sqf
+++ b/loadouts/T1_Bundeswehr_D/bw_o_dmr.sqf
@@ -54,7 +54,7 @@ _unit addItemToUniform "ACRE_PRC343";
 
 if (isNil "SR_Night") then {SR_Night = false};
 if (SR_Night) then {
-	_unit linkItem "rhsusf_ANPVS_15";
+	_unit linkItem "A3_GPNVG18_BLK_F";
 	_unit setUnitTrait ["camouflageCoef",SR_Camo_Coef];
 };
 _unit setVariable ["SR_Class","SDMR", true];

--- a/loadouts/T1_Bundeswehr_D/bw_o_e_demo.sqf
+++ b/loadouts/T1_Bundeswehr_D/bw_o_e_demo.sqf
@@ -27,12 +27,11 @@ for "_i" from 1 to 2 do {_unit addItemToVest "BWA3_DM51A1";};
 for "_i" from 1 to 4 do {_unit addItemToVest "rhs_mag_mk84";};
 _unit addBackpack "BWA3_Kitbag_Tropen";
 for "_i" from 1 to 3 do {_unit addItemToBackpack "ACE_CableTie";};
-unit addItemToBackpack "ACE_DefusalKit";
+_unit addItemToBackpack "ACE_DefusalKit";
 _unit addItemToBackpack "ACE_Clacker";
 _unit addItemToBackpack "ACE_EntrenchingTool";
-_unit addItemToBackpack "ACE_SpraypaintGreen";
 _unit addItemToBackpack "SatchelCharge_Remote_Mag";
-for "_i" from 1 to 2 do {_unit addItemToBackpack "DemoCharge_Remote_Mag";}
+for "_i" from 1 to 2 do {_unit addItemToBackpack "DemoCharge_Remote_Mag";};
 _unit addHeadgear "milgp_h_airframe_03_goggles_khk_hexagon";
 _unit addGoggles "shemagh_loosetanBG";
 
@@ -57,7 +56,7 @@ _unit addItemToUniform "ACRE_PRC343";
 
 if (isNil "SR_Night") then {SR_Night = false};
 if (SR_Night) then {
-	_unit linkItem "rhsusf_ANPVS_15";
+	_unit linkItem "A3_GPNVG18_BLK_F";
 	_unit setUnitTrait ["camouflageCoef",SR_Camo_Coef];
 };
 _unit setVariable ["SR_Class","E", true];

--- a/loadouts/T1_Bundeswehr_D/bw_o_e_eod.sqf
+++ b/loadouts/T1_Bundeswehr_D/bw_o_e_eod.sqf
@@ -27,11 +27,10 @@ for "_i" from 1 to 2 do {_unit addItemToVest "BWA3_DM51A1";};
 for "_i" from 1 to 4 do {_unit addItemToVest "rhs_mag_mk84";};
 _unit addBackpack "BWA3_Kitbag_Tropen";
 for "_i" from 1 to 3 do {_unit addItemToBackpack "ACE_CableTie";};
-unit addItemToBackpack "ACE_DefusalKit";
+_unit addItemToBackpack "ACE_DefusalKit";
 _unit addItemToBackpack "MineDetector";
 _unit addItemToBackpack "ACE_EntrenchingTool";
 _unit addItemToBackpack "ACE_SpraypaintRed";
-_unit addItemToBackpack "ACE_SpraypaintGreen";
 _unit addHeadgear "milgp_h_airframe_03_goggles_khk_hexagon";
 _unit addGoggles "shemagh_loosetanBG";
 
@@ -56,7 +55,7 @@ _unit addItemToUniform "ACRE_PRC343";
 
 if (isNil "SR_Night") then {SR_Night = false};
 if (SR_Night) then {
-	_unit linkItem "rhsusf_ANPVS_15";
+	_unit linkItem "A3_GPNVG18_BLK_F";
 	_unit setUnitTrait ["camouflageCoef",SR_Camo_Coef];
 };
 _unit setVariable ["SR_Class","E", true];

--- a/loadouts/T1_Bundeswehr_D/bw_o_e_fort.sqf
+++ b/loadouts/T1_Bundeswehr_D/bw_o_e_fort.sqf
@@ -27,7 +27,7 @@ for "_i" from 1 to 2 do {_unit addItemToVest "BWA3_DM51A1";};
 for "_i" from 1 to 4 do {_unit addItemToVest "rhs_mag_mk84";};
 _unit addBackpack "BWA3_Kitbag_Tropen";
 for "_i" from 1 to 3 do {_unit addItemToBackpack "ACE_CableTie";};
-_unit add_unit addItemToBackpack "ACE_Clacker";
+_unit addItemToBackpack "ACE_Clacker";
 _unit addItemToBackpack "ACE_EntrenchingTool";
 _unit addItemToBackpack "ACE_ConstructionTool";
 for "_i" from 1 to 2 do {_unit addItemToBackpack "SLAMDirectionalMine_Wire_Mag";};
@@ -56,7 +56,7 @@ _unit addItemToUniform "ACRE_PRC343";
 
 if (isNil "SR_Night") then {SR_Night = false};
 if (SR_Night) then {
-	_unit linkItem "rhsusf_ANPVS_15";
+	_unit linkItem "A3_GPNVG18_BLK_F";
 	_unit setUnitTrait ["camouflageCoef",SR_Camo_Coef];
 };
 _unit setVariable ["SR_Class","E", true];

--- a/loadouts/T1_Bundeswehr_D/bw_o_e_rep.sqf
+++ b/loadouts/T1_Bundeswehr_D/bw_o_e_rep.sqf
@@ -29,7 +29,6 @@ _unit addBackpack "BWA3_Kitbag_Tropen";
 for "_i" from 1 to 3 do {_unit addItemToBackpack "ACE_CableTie";};
 _unit addItemToBackpack "ToolKit";
 _unit addItemToBackpack "ACE_EntrenchingTool";
-_unit addItemToBackpack "ACE_SpraypaintGreen";
 _unit addHeadgear "milgp_h_airframe_03_goggles_khk_hexagon";
 _unit addGoggles "shemagh_loosetanBG";
 
@@ -54,7 +53,7 @@ _unit addItemToUniform "ACRE_PRC343";
 
 if (isNil "SR_Night") then {SR_Night = false};
 if (SR_Night) then {
-	_unit linkItem "rhsusf_ANPVS_15";
+	_unit linkItem "A3_GPNVG18_BLK_F";
 	_unit setUnitTrait ["camouflageCoef",SR_Camo_Coef];
 };
 _unit setVariable ["SR_Class","E", true];

--- a/loadouts/T1_Bundeswehr_D/bw_o_g.sqf
+++ b/loadouts/T1_Bundeswehr_D/bw_o_g.sqf
@@ -55,7 +55,7 @@ _unit addItemToUniform "ACRE_PRC343";
 if (isNil "SR_Night") then {SR_Night = false};
 if (SR_Night) then {
 	for "_i" from 1 to 6 do {_unit addItemToBackpack "UGL_FlareWhite_F";};
-	_unit linkItem "rhsusf_ANPVS_15";
+	_unit linkItem "A3_GPNVG18_BLK_F";
 	_unit setUnitTrait ["camouflageCoef",SR_Camo_Coef];
 };
 _unit setVariable ["SR_Class","G", true];

--- a/loadouts/T1_Bundeswehr_D/bw_o_lat1.sqf
+++ b/loadouts/T1_Bundeswehr_D/bw_o_lat1.sqf
@@ -54,7 +54,7 @@ _unit addItemToUniform "ACRE_PRC343";
 
 if (isNil "SR_Night") then {SR_Night = false};
 if (SR_Night) then {
-	_unit linkItem "rhsusf_ANPVS_15";
+	_unit linkItem "A3_GPNVG18_BLK_F";
 	_unit setUnitTrait ["camouflageCoef",SR_Camo_Coef];
 };
 _unit setVariable ["SR_Class","LAT", true];

--- a/loadouts/T1_Bundeswehr_D/bw_o_lat2.sqf
+++ b/loadouts/T1_Bundeswehr_D/bw_o_lat2.sqf
@@ -54,7 +54,7 @@ _unit addItemToUniform "ACRE_PRC343";
 
 if (isNil "SR_Night") then {SR_Night = false};
 if (SR_Night) then {
-	_unit linkItem "rhsusf_ANPVS_15";
+	_unit linkItem "A3_GPNVG18_BLK_F";
 	_unit setUnitTrait ["camouflageCoef",SR_Camo_Coef];
 };
 _unit setVariable ["SR_Class","LAT", true];

--- a/loadouts/T1_Bundeswehr_D/bw_o_mat.sqf
+++ b/loadouts/T1_Bundeswehr_D/bw_o_mat.sqf
@@ -51,7 +51,7 @@ _unit addItemToUniform "ACRE_PRC343";
 
 if (isNil "SR_Night") then {SR_Night = false};
 if (SR_Night) then {
-	_unit linkItem "rhsusf_ANPVS_15";
+	_unit linkItem "A3_GPNVG18_BLK_F";
 	_unit setUnitTrait ["camouflageCoef",SR_Camo_Coef];
 };
 _unit setVariable ["SR_Class","MAT", true];

--- a/loadouts/T1_Bundeswehr_D/bw_o_mat_ab.sqf
+++ b/loadouts/T1_Bundeswehr_D/bw_o_mat_ab.sqf
@@ -54,7 +54,7 @@ _unit addItemToUniform "ACRE_PRC343";
 
 if (isNil "SR_Night") then {SR_Night = false};
 if (SR_Night) then {
-	_unit linkItem "rhsusf_ANPVS_15";
+	_unit linkItem "A3_GPNVG18_BLK_F";
 	_unit setUnitTrait ["camouflageCoef",SR_Camo_Coef];
 };
 _unit setVariable ["SR_Class","MATAB", true];

--- a/loadouts/T1_Bundeswehr_D/bw_o_mmg_ab.sqf
+++ b/loadouts/T1_Bundeswehr_D/bw_o_mmg_ab.sqf
@@ -53,7 +53,7 @@ _unit addItemToUniform "ACRE_PRC343";
 
 if (isNil "SR_Night") then {SR_Night = false};
 if (SR_Night) then {
-	_unit linkItem "rhsusf_ANPVS_15";
+	_unit linkItem "A3_GPNVG18_BLK_F";
 	_unit setUnitTrait ["camouflageCoef",SR_Camo_Coef];
 };
 _unit setVariable ["SR_Class","MMGAB", true];

--- a/loadouts/T1_Bundeswehr_D/bw_o_mmg_mg5.sqf
+++ b/loadouts/T1_Bundeswehr_D/bw_o_mmg_mg5.sqf
@@ -29,7 +29,7 @@ _unit addHeadgear "milgp_h_airframe_01_RGR";
 _unit addGoggles "shemagh_goggclr_tan";
 
 comment "Add weapons";
-__unit addWeapon "BWA3_MG5";
+_unit addWeapon "BWA3_MG5";
 _unit addPrimaryWeaponItem "BWA3_acc_VarioRay_irlaser";
 _unit addWeapon "RH_usp";
 _unit addHandgunItem "RH_gemtech45";
@@ -49,7 +49,7 @@ _unit addItemToUniform "ACRE_PRC343";
 
 if (isNil "SR_Night") then {SR_Night = false};
 if (SR_Night) then {
-	_unit linkItem "rhsusf_ANPVS_15";
+	_unit linkItem "A3_GPNVG18_BLK_F";
 	_unit setUnitTrait ["camouflageCoef",SR_Camo_Coef];
 };
 _unit setVariable ["SR_Class","MMG", true];

--- a/loadouts/T1_Bundeswehr_D/bw_o_r.sqf
+++ b/loadouts/T1_Bundeswehr_D/bw_o_r.sqf
@@ -52,7 +52,7 @@ _unit addItemToUniform "ACRE_PRC343";
 
 if (isNil "SR_Night") then {SR_Night = false};
 if (SR_Night) then {
-	_unit linkItem "rhsusf_ANPVS_15";
+	_unit linkItem "A3_GPNVG18_BLK_F";
 	_unit setUnitTrait ["camouflageCoef",SR_Camo_Coef];
 };
 _unit setVariable ["SR_Class","R", true];

--- a/loadouts/T1_Bundeswehr_D/bw_p_ar.sqf
+++ b/loadouts/T1_Bundeswehr_D/bw_p_ar.sqf
@@ -53,7 +53,7 @@ if (isNil "SR_Night") then {SR_Night = false};
 if (SR_Night) then {
 	removeHeadgear _unit;
 	_unit addHeadgear "milgp_h_airframe_01_RGR";
-	_unit linkItem "rhsusf_ANPVS_15";
+	_unit linkItem "A3_GPNVG18_BLK_F";
 	_unit setUnitTrait ["camouflageCoef",SR_Camo_Coef];
 };
 _unit setVariable ["SR_Class","PAR", true];

--- a/loadouts/T1_Bundeswehr_D/bw_p_d.sqf
+++ b/loadouts/T1_Bundeswehr_D/bw_p_d.sqf
@@ -50,7 +50,7 @@ if (isNil "SR_Night") then {SR_Night = false};
 if (SR_Night) then {
 	removeHeadgear _unit;
 	_unit addHeadgear "milgp_h_airframe_01_goggles_khk";
-	_unit linkItem "rhsusf_ANPVS_15";
+	_unit linkItem "A3_GPNVG18_BLK_F";
 	_unit setUnitTrait ["camouflageCoef",SR_Camo_Coef];
 };
 _unit setVariable ["SR_Class","PD", true];

--- a/loadouts/T1_Bundeswehr_D/bw_p_dmr.sqf
+++ b/loadouts/T1_Bundeswehr_D/bw_p_dmr.sqf
@@ -52,7 +52,7 @@ if (isNil "SR_Night") then {SR_Night = false};
 if (SR_Night) then {
 	removeHeadgear _unit;
 	_unit addHeadgear "milgp_h_airframe_02_khk_hexagon";
-	_unit linkItem "rhsusf_ANPVS_15";
+	_unit linkItem "A3_GPNVG18_BLK_F";
 	_unit setUnitTrait ["camouflageCoef",SR_Camo_Coef];
 };
 _unit setVariable ["SR_Class","PDMR", true];

--- a/loadouts/T1_Bundeswehr_D/bw_p_e_demo.sqf
+++ b/loadouts/T1_Bundeswehr_D/bw_p_e_demo.sqf
@@ -60,7 +60,7 @@ if (isNil "SR_Night") then {SR_Night = false};
 if (SR_Night) then {
 	removeHeadgear _unit;
 	_unit addHeadgear "milgp_h_airframe_03_goggles_khk_hexagon";
-	_unit linkItem "rhsusf_ANPVS_15";
+	_unit linkItem "A3_GPNVG18_BLK_F";
 	_unit setUnitTrait ["camouflageCoef",SR_Camo_Coef];
 };
 _unit setVariable ["SR_Class","PE", true];

--- a/loadouts/T1_Bundeswehr_D/bw_p_e_eod.sqf
+++ b/loadouts/T1_Bundeswehr_D/bw_p_e_eod.sqf
@@ -28,7 +28,7 @@ for "_i" from 1 to 2 do {_unit addItemToVest "rhs_mag_mk84";};
 _unit addBackpack "BWA3_Kitbag_Tropen";
 for "_i" from 1 to 3 do {_unit addItemToBackpack "ACE_CableTie";};
 _unit addItemToBackpack "ACE_Clacker";
-unit addItemToBackpack "ACE_DefusalKit";
+_unit addItemToBackpack "ACE_DefusalKit";
 _unit addItemToBackpack "MineDetector";
 _unit addItemToBackpack "ACE_EntrenchingTool";
 _unit addItemToBackpack "ACE_SpraypaintRed";
@@ -63,7 +63,7 @@ if (isNil "SR_Night") then {SR_Night = false};
 if (SR_Night) then {
 	removeHeadgear _unit;
 	_unit addHeadgear "milgp_h_airframe_03_goggles_khk_hexagon";
-	_unit linkItem "rhsusf_ANPVS_15";
+	_unit linkItem "A3_GPNVG18_BLK_F";
 	_unit setUnitTrait ["camouflageCoef",SR_Camo_Coef];
 };
 _unit setVariable ["SR_Class","PE", true];

--- a/loadouts/T1_Bundeswehr_D/bw_p_e_fort.sqf
+++ b/loadouts/T1_Bundeswehr_D/bw_p_e_fort.sqf
@@ -29,6 +29,7 @@ _unit addBackpack "BWA3_Kitbag_Tropen";
 for "_i" from 1 to 3 do {_unit addItemToBackpack "ACE_CableTie";};
 _unit addItemToBackpack "ACE_Clacker";
 _unit addItemToBackpack "ACE_EntrenchingTool";
+_unit addItemToBackpack "ACE_SpraypaintGreen";
 _unit addItemToBackpack "ACE_ConstructionTool";
 for "_i" from 1 to 2 do {_unit addItemToBackpack "SLAMDirectionalMine_Wire_Mag";};
 for "_i" from 1 to 4 do {_unit addItemToBackpack "ClaymoreDirectionalMine_Remote_Mag";};
@@ -60,7 +61,7 @@ if (isNil "SR_Night") then {SR_Night = false};
 if (SR_Night) then {
 	removeHeadgear _unit;
 	_unit addHeadgear "milgp_h_airframe_03_goggles_khk_hexagon";
-	_unit linkItem "rhsusf_ANPVS_15";
+	_unit linkItem "A3_GPNVG18_BLK_F";
 	_unit setUnitTrait ["camouflageCoef",SR_Camo_Coef];
 };
 _unit setVariable ["SR_Class","PE", true];

--- a/loadouts/T1_Bundeswehr_D/bw_p_e_rep.sqf
+++ b/loadouts/T1_Bundeswehr_D/bw_p_e_rep.sqf
@@ -58,7 +58,7 @@ if (isNil "SR_Night") then {SR_Night = false};
 if (SR_Night) then {
 	removeHeadgear _unit;
 	_unit addHeadgear "milgp_h_airframe_03_goggles_khk_hexagon";
-	_unit linkItem "rhsusf_ANPVS_15";
+	_unit linkItem "A3_GPNVG18_BLK_F";
 	_unit setUnitTrait ["camouflageCoef",SR_Camo_Coef];
 };
 _unit setVariable ["SR_Class","PE", true];

--- a/loadouts/T1_Bundeswehr_D/bw_p_fac.sqf
+++ b/loadouts/T1_Bundeswehr_D/bw_p_fac.sqf
@@ -29,7 +29,6 @@ for "_i" from 1 to 2 do {_unit addItemToVest "BWA3_DM32_Orange";};
 for "_i" from 1 to 2 do {_unit addItemToVest "rhs_mag_mk84";};
 _unit addBackpack "tf_rt1523g_big_bwmod_tropen";
 for "_i" from 1 to 3 do {_unit addItemToBackpack "ACE_CableTie";};
-_unit addItemToBackpack "ACE_SpraypaintGreen";
 _unit addHeadgear "PBW_barett_ksk";
 _unit addGoggles "shemagh_loosetanBG";
 
@@ -59,7 +58,7 @@ if (SR_Night) then {
 	removeHeadgear _unit;
 	_unit addHeadgear "milgp_h_airframe_06_khk";
 	for "_i" from 1 to 2 do {_unit addItemToBackpack "ACE_HandFlare_Green";};
-	_unit linkItem "rhsusf_ANPVS_15";
+	_unit linkItem "A3_GPNVG18_BLK_F";
 	_unit setUnitTrait ["camouflageCoef",SR_Camo_Coef];
 };
 _unit setVariable ["SR_Class","FAC", true];

--- a/loadouts/T1_Bundeswehr_D/bw_p_medic.sqf
+++ b/loadouts/T1_Bundeswehr_D/bw_p_medic.sqf
@@ -31,7 +31,8 @@ for "_i" from 1 to 3 do {_unit addItemToBackpack "SR_Bandage_Pack";};
 for "_i" from 1 to 3 do {_unit addItemToBackpack "SR_Medicine_Pack";};
 for "_i" from 1 to 2 do {_unit addItemToBackpack "SR_BloodIV_Pack";};
 for "_i" from 1 to 2 do {_unit addItemToBackpack "BWA3_DM32_Blue";};
-_unit addItemToBackpack "BWA3_DM25";};
+_unit addItemToBackpack "BWA3_DM25";
+_unit addItemToBackpack "ACE_SpraypaintBlue";
 _unit addHeadgear "PBW_barett_ksk";
 _unit addGoggles "shemagh_loosetanBG";
 
@@ -56,7 +57,7 @@ if (isNil "SR_Night") then {SR_Night = false};
 if (SR_Night) then {
 	removeHeadgear _unit;
 	_unit addHeadgear "milgp_h_airframe_05_goggles_RGR_hexagon";
-	_unit linkItem "rhsusf_ANPVS_15";
+	_unit linkItem "A3_GPNVG18_BLK_F";
 	_unit setUnitTrait ["camouflageCoef",SR_Camo_Coef];
 };
 _unit setVariable ["SR_Class","PM", true];

--- a/loadouts/T1_Bundeswehr_D/bw_pl.sqf
+++ b/loadouts/T1_Bundeswehr_D/bw_pl.sqf
@@ -68,7 +68,7 @@ if (SR_Night) then {
 	_unit addItemToBackpack "UGL_FlareWhite_F";
 	_unit addItemToBackpack "UGL_FlareRed_F";
 	_unit addItemToBackpack "UGL_FlareRed_F";
-	_unit linkItem "rhsusf_ANPVS_15";
+	_unit linkItem "A3_GPNVG18_BLK_F";
 	_unit setUnitTrait ["camouflageCoef",SR_Camo_Coef];
 };
 _unit setVariable ["SR_Class","PL", true];

--- a/loadouts/T1_Bundeswehr_D/bw_sl.sqf
+++ b/loadouts/T1_Bundeswehr_D/bw_sl.sqf
@@ -34,7 +34,6 @@ for "_i" from 1 to 4 do {_unit addItemToBackpack "1Rnd_Smoke_Grenade_shell";};
 for "_i" from 1 to 2 do {_unit addItemToBackpack "1Rnd_SmokeRed_Grenade_shell";};
 for "_i" from 1 to 2 do {_unit addItemToBackpack "1Rnd_SmokeYellow_Grenade_shell";};
 for "_i" from 1 to 2 do {_unit addItemToBackpack "DemoCharge_Remote_Mag";};
-_unit addItemToBackpack "ACE_SpraypaintGreen";
 _unit addHeadgear "milgp_h_airframe_03_RGR_hexagon";
 _unit addGoggles "goggles_blk";
 
@@ -67,7 +66,7 @@ if (SR_Night) then {
 	_unit addItemToBackpack "UGL_FlareWhite_F";
 	_unit addItemToBackpack "UGL_FlareRed_F";
 	_unit addItemToBackpack "UGL_FlareRed_F";
-	_unit linkItem "rhsusf_ANPVS_15";
+	_unit linkItem "A3_GPNVG18_BLK_F";
 	_unit setUnitTrait ["camouflageCoef",SR_Camo_Coef];
 };
 _unit setVariable ["SR_Class","SL", true];

--- a/loadouts/T1_Bundeswehr_D/bw_uav.sqf
+++ b/loadouts/T1_Bundeswehr_D/bw_uav.sqf
@@ -51,7 +51,7 @@ _unit addItemToUniform "ACRE_PRC343";
 
 if (isNil "SR_Night") then {SR_Night = false};
 if (SR_Night) then {
-	_unit linkItem "rhsusf_ANPVS_15";
+	_unit linkItem "A3_GPNVG18_BLK_F";
 	_unit setUnitTrait ["camouflageCoef",SR_Camo_Coef];
 };
 _unit setVariable ["SR_Class","UO", true];


### PR DESCRIPTION
- Changed NVGs from `rhsusf_ANPVS_15` to `A3_GPNVG18_BLK_F`
- Removed spraypaint from loadouts that should not have it
  - Echo Demo
  - Echo EOD
  - Echo Repair
  - Operator Demo
  - Operator EOD
  - Operator Repair
  - Platoon FAC
  - SL
- Added spraypaint to loadouts that should have it, but didn't
  - Platoon Medic
  - Platoon Fortifications
- Fixed various script errors
  - Echo AR
  - Echo EOD
  - Foxtrot Commander
  - Operator AR
  - Operator Demo
  - Operator EOD
  - Operator Fortifications
  - Operator MMG
  - Platoon EOD
  - Platoon Medic

Thanks to Zali for doing most of the error fixing.