### PR TITLE
Vehicle supply drop Fix

### DIFF
--- a/Framework Files/7R/Supplies/fn_supplyDropInit.sqf
+++ b/Framework Files/7R/Supplies/fn_supplyDropInit.sqf
@@ -88,8 +88,7 @@ if (count _vehicle == 0) then {
 	};
 } else {
 	// Vehicle Drop
-	_veh = createVehicle [_vehicleClass, [0,0,0], [], 0, "NONE"];
-	_veh allowDamage false;
+	_veh = createVehicle [_vehicleClass, [0,0,1000], [], 0, "NONE"];
 	_veh disableCollisionWith _planeacc;
 	if (_vehicleLoadout >= 0) then {
 		[_veh, _vehicleLoadout] execVM "loadouts\_vehicle_cargo_content.sqf";


### PR DESCRIPTION
Fix to the vehicle supply drop. Change spawn from [0.0.0](which is in the water) to [0.0.1000].