### PR TITLE
Fixed fn_spawnTemplate.sqf for air vehicles

### DIFF
--- a/Framework Files/7R/Templates/fn_spawnTemplate.sqf
+++ b/Framework Files/7R/Templates/fn_spawnTemplate.sqf
@@ -147,7 +147,7 @@ if (_type isEqualTo "AIR") Then {
 	(_vehicle select 0) disableTIEquipment true;
 
 	// Initialise Group
-	private _leader = leader (_veh select 2);
+	private _leader = leader (_vehicle select 2);
 	_grp = group _leader;
 	_grp deleteGroupWhenEmpty true;
 	_params params ["_tMarker","_wpType","_mode","_pZone"];


### PR DESCRIPTION
Air vehicles with more than 1 unit in them wouldn't move to marker. This was due to variable on line 150 being _veh instead of _vehicle . Changed these two over and now works.