### PR TITLE
Add new uniforms box interaction

### DIFF
--- a/Framework Files/7R/Loadouts/fn_addUniformsToBox.sqf
+++ b/Framework Files/7R/Loadouts/fn_addUniformsToBox.sqf
@@ -1,0 +1,90 @@
+/*
+    Parameters:
+        <-- Uniforms box as Object
+        <-- Array of uniforms
+
+    Description:
+        Adds loadouts/uniforms to the uniform box.
+
+    Example (in _uniforms_box.sqf):
+        [this, _uniforms] call fw_fnc_addUniformsToBox;
+
+        _uniforms should be in this format:
+        [
+            [
+                ["Element name", "Element color", "Element icon"],
+                [
+                    ["Uniform name", "UniformFile"],
+                    ["Uniform name", "UniformFile"],
+                    ["Uniform name", "UniformFile"]
+                ]
+            ],
+            [
+                ["Element name", "Element color", "Element icon"],
+                [
+                    ["Uniform name", "UniformFile"],
+                    ["Uniform name", "UniformFile"],
+                    ["Uniform name", "UniformFile"]
+                ]
+            ]
+        ]
+
+    Return:
+        --> Nil
+*/
+
+params ["_box", "_uniforms"];
+
+// Clear all other interactions from the object.
+[_box, _box] call ace_common_fnc_claim;
+
+private _maxSelectionDistance = 20;
+private _uniformsBoxActionName = "UniformsBoxAction";
+
+private _uniformsBoxAction = [
+    _uniformsBoxActionName,
+    "Choose loadout",
+    "a3\ui_f\data\igui\cfg\simpletasks\types\rifle_ca.paa",
+    {},                 // statement
+    {true},             // condition
+    {},                 // children
+    [],                 // args
+    "",                 // position
+    _maxSelectionDistance
+] call ace_interact_menu_fnc_createAction;
+[_box, 0, [], _uniformsBoxAction] call ace_interact_menu_fnc_addActionToObject;
+
+{ // Loop over every element in the uniforms array.
+    private _element = _x select 0;
+    private _element_name = _element select 0;
+    private _element_color = _element select 1;
+    private _element_icon = _element select 2;
+    private _element_uniforms = _x select 1;
+    private _elementAction = [_element_name, [_element_name, _element_color] call fw_fnc_makeColor, _element_icon, {}, {true}, {}, [], "", _maxSelectionDistance] call ace_interact_menu_fnc_createAction;
+    [_box, 0, [_uniformsBoxActionName], _elementAction] call ace_interact_menu_fnc_addActionToObject;
+
+    { // Loop over every uniform in the element.
+        private _uniform = _x select 0;
+        private _uniform_file = _x select 1;
+        private _uniformStatement = {
+            params ["_target", "_player", "_params"];
+            call compile preprocessFileLineNumbers _params select 0;
+        };
+        private _uniformAction = [_uniform, _uniform, "", _uniformStatement, {true}, {}, _uniform_file, "", _maxSelectionDistance] call ace_interact_menu_fnc_createAction;
+        [_box, 0, [_uniformsBoxActionName, _element_name], _uniformAction] call ace_interact_menu_fnc_addActionToObject;
+
+        // LEGACY: scroll interaction
+        _box addaction [_uniform, _uniform_file];
+
+    } forEach _element_uniforms;
+
+} forEach _uniforms;
+
+private _saveAction = ["SaveLoadout", ["Save Loadout", "#ffffff"] call fw_fnc_makeColor, "", {(_this select 1) setVariable ["SR_uniform", getUnitLoadout (_this select 1)];}, {true}, {}, [], "", _maxSelectionDistance] call ace_interact_menu_fnc_createAction;
+[_box, 0, [_uniformsBoxActionName], _saveAction] call ace_interact_menu_fnc_addActionToObject;
+private _loadAction = ["LoadLoadout", ["Load Loadout", "#ffffff"] call fw_fnc_makeColor, "", {(_this select 1) setUnitLoadout ((_this select 1) getVariable ["SR_uniform", []]);}, {true}, {}, [], "", _maxSelectionDistance] call ace_interact_menu_fnc_createAction;
+[_box, 0, [_uniformsBoxActionName], _loadAction] call ace_interact_menu_fnc_addActionToObject;
+
+// LEGACY: scroll interaction
+_box addaction [["Save Loadout", "#00ffff"] call fw_fnc_makeColor, {(_this select 1) setVariable ["SR_uniform", getUnitLoadout (_this select 1)];}];
+_box addaction [["Load Loadout", "#00ffff"] call fw_fnc_makeColor, {(_this select 1) setUnitLoadout ((_this select 1) getVariable ["SR_uniform", []]);}];

--- a/Framework Files/7R/Loadouts/fn_addUniformsToBox.sqf
+++ b/Framework Files/7R/Loadouts/fn_addUniformsToBox.sqf
@@ -11,22 +11,16 @@
 
         _uniforms should be in this format:
         [
-            [
-                ["Element name", "Element color", "Element icon"],
-                [
-                    ["Uniform name", "UniformFile"],
-                    ["Uniform name", "UniformFile"],
-                    ["Uniform name", "UniformFile"]
-                ]
-            ],
-            [
-                ["Element name", "Element color", "Element icon"],
-                [
-                    ["Uniform name", "UniformFile"],
-                    ["Uniform name", "UniformFile"],
-                    ["Uniform name", "UniformFile"]
-                ]
-            ]
+            ["Element name", "Element color", "Element icon", [
+                ["Uniform name", "UniformFile"],
+                ["Uniform name", "UniformFile"],
+                ["Uniform name", "UniformFile"]
+            ]],
+            ["Element name", "Element color", "Element icon", [
+                ["Uniform name", "UniformFile"],
+                ["Uniform name", "UniformFile"],
+                ["Uniform name", "UniformFile"]
+            ]]
         ]
 
     Return:
@@ -55,11 +49,10 @@ private _uniformsBoxAction = [
 [_box, 0, [], _uniformsBoxAction] call ace_interact_menu_fnc_addActionToObject;
 
 { // Loop over every element in the uniforms array.
-    private _element = _x select 0;
-    private _element_name = _element select 0;
-    private _element_color = _element select 1;
-    private _element_icon = _element select 2;
-    private _element_uniforms = _x select 1;
+    private _element_name = _x select 0;
+    private _element_color = _x select 1;
+    private _element_icon = _x select 2;
+    private _element_uniforms = _x select 3;
     private _elementAction = [_element_name, [_element_name, _element_color] call fw_fnc_makeColor, _element_icon, {}, {true}, {}, [], "", _maxSelectionDistance] call ace_interact_menu_fnc_createAction;
     [_box, 0, [_uniformsBoxActionName], _elementAction] call ace_interact_menu_fnc_addActionToObject;
 

--- a/Framework Files/7R/Shared/functions.hpp
+++ b/Framework Files/7R/Shared/functions.hpp
@@ -167,5 +167,10 @@
 		class addEquipmentRadios{};
 		class addEquipmentItems{};
 		class conditionEquipment{};
+		class addUniformsToBox{};
+	};
+	class Text {
+		file = "7R\Text";
+		class makeColor{};
 	}
 };

--- a/Framework Files/7R/Text/fn_makeColor.sqf
+++ b/Framework Files/7R/Text/fn_makeColor.sqf
@@ -1,0 +1,17 @@
+/*
+    Parameters:
+        <-- Text to color as String
+        <-- Color as String
+
+    Description:
+        Adds color to a piece of text.
+
+    Example (in _uniforms_box.sqf):
+        _coloredText = ["Operator", "#00ff00"] call fw_fnc_makeColor;
+
+    Return:
+        --> String
+*/
+
+params ["_text", "_color"];
+format ["<t color='%1'>%2</t>", _color, _text];


### PR DESCRIPTION
Add an ACE interaction menu to the uniforms box to select a loadout.
The player must stand ~15m or closer to the box for the menu to appear (seems to be the max in ACE).

![image](https://github.com/DextroNC/Framework/assets/3472373/8aac701d-8c90-4032-a299-09b6a1e95880)

Players moving into the sightline to the box have less of an impact, and only break the interaction when really close to the interacting player (they then capture the interaction menu for medical options etc).

![image](https://github.com/DextroNC/Framework/assets/3472373/1327e511-1b61-40fd-80c0-f89f57e7d649)

The 'normal' scrollwheel actions are also still available.

![image](https://github.com/DextroNC/Framework/assets/3472373/27b80ecc-6989-4f6c-801f-a92f4f36ec5d)

To enable this menu, the `loadouts\_uniforms_box.sqf` file of each loadout needs to be edited, which is too big of a change to do at once. Since we're updating loadouts gradually anyway, we can include this change for new or updated loadouts.