### PR TITLE
Dynamic Garrisons Update

### DIFF
--- a/Framework Files/7R/AI/Common/fn_garrison.sqf
+++ b/Framework Files/7R/AI/Common/fn_garrison.sqf
@@ -43,6 +43,7 @@ SR_PatrolUnits pushBackUnique _group;
 
 							if (selectRandomWeighted [true,SR_ReleaseProbability,false,1-SR_ReleaseProbability]) then {
 								_x enableAI "PATH";
+								_x setCombatBehaviour "COMBAT";
 
 								// Debug
 								if (SR_Debug) then { format ["%1 now has pathing enabled", _x] remoteExec ["systemChat", 0]; };

--- a/Framework Files/7R/AI/Common/fn_garrison.sqf
+++ b/Framework Files/7R/AI/Common/fn_garrison.sqf
@@ -27,38 +27,11 @@ _group = group (_units select 0);
 _group deleteGroupWhenEmpty true;
 SR_PatrolUnits pushBackUnique _group;
 
-{// Add event handler globally to enable pathing on nearby group members when ally is killed
-
-	[_x,
-		["Killed", 
-			{
-				params ["_unit", "_killer", "_instigator", "_useEffects"];
-
-				// Debug
-				if (SR_Debug) then { format ["%1 was killed", _unit] remoteExec ["systemChat", 0]; };
-
-				if ((_unit distance2D _instigator) < SR_InstigatorDistance) then {
-					{
-						if ((_unit distance2D _x) < SR_ReleaseDistance) then {
-
-							if (selectRandomWeighted [true,SR_ReleaseProbability,false,1-SR_ReleaseProbability]) then {
-								_x enableAI "PATH";
-								_x setCombatBehaviour "COMBAT";
-
-								// Debug
-								if (SR_Debug) then { format ["%1 now has pathing enabled", _x] remoteExec ["systemChat", 0]; };
-							};
-
-							[_x ,["Killed", _thisEventHandler]] remoteExec ["removeEventHandler", 0];
-
-						};
-					} forEach (units _unit);
-				};
-			} 
-		]
-	] remoteExec ["addEventHandler", 0, true];
-	
+// Add event handler  to enable pathing on nearby group members when ally is killed
+{
+	[_x] spawn fw_fnc_garrisonKilledEH;
 } forEach _units;
+
 
 // Debug
 if (SR_Debug) then { format ["%1 garrison %2 with radius %3", group (_units select 0), mapGridPosition _position, _radius] remoteExec ["systemChat", 0]; };

--- a/Framework Files/7R/AI/Common/fn_garrison.sqf
+++ b/Framework Files/7R/AI/Common/fn_garrison.sqf
@@ -27,5 +27,37 @@ _group = group (_units select 0);
 _group deleteGroupWhenEmpty true;
 SR_PatrolUnits pushBackUnique _group;
 
+{// Add event handler globally to enable pathing on nearby group members when ally is killed
+
+	[_x,
+		["Killed", 
+			{
+				params ["_unit", "_killer", "_instigator", "_useEffects"];
+
+				// Debug
+				if (SR_Debug) then { format ["%1 was killed", _unit] remoteExec ["systemChat", 0]; };
+
+				if ((_unit distance2D _instigator) < SR_InstigatorDistance) then {
+					{
+						if ((_unit distance2D _x) < SR_ReleaseDistance) then {
+
+							if (selectRandomWeighted [true,SR_ReleaseProbability,false,1-SR_ReleaseProbability]) then {
+								_x enableAI "PATH";
+
+								// Debug
+								if (SR_Debug) then { format ["%1 now has pathing enabled", _x] remoteExec ["systemChat", 0]; };
+							};
+
+							[_x ,["Killed", _thisEventHandler]] remoteExec ["removeEventHandler", 0];
+
+						};
+					} forEach (units _unit);
+				};
+			} 
+		]
+	] remoteExec ["addEventHandler", 0, true];
+	
+} forEach _units;
+
 // Debug
-if (SR_Debug) then { systemChat format ["%1 garrison %2 with radius %3", group (_units select 0), mapGridPosition _position, _radius]; };
+if (SR_Debug) then { format ["%1 garrison %2 with radius %3", group (_units select 0), mapGridPosition _position, _radius] remoteExec ["systemChat", 0]; };

--- a/Framework Files/7R/AI/Common/fn_garrisonZEI.sqf
+++ b/Framework Files/7R/AI/Common/fn_garrisonZEI.sqf
@@ -34,5 +34,10 @@ private _bldPos = (_building select 0) buildingPos -1;
 	[_group, _x, _rndPos, (_building select 0)] call ZEI_fnc_garrisonUnit;
 } forEach _units;
 
+// Add event handler  to enable pathing on nearby group members when ally is killed
+{
+	[_x] spawn fw_fnc_garrisonKilledEH;
+} forEach units _group;
+
 // Debug
 if (SR_Debug) then { systemChat format ["%1 garrison %2", group (_units select 0), mapGridPosition _position];};

--- a/Framework Files/7R/AI/Eventhandler/fn_garrisonKilledEH.sqf
+++ b/Framework Files/7R/AI/Eventhandler/fn_garrisonKilledEH.sqf
@@ -1,0 +1,53 @@
+/*
+	Parameters:
+		<-- Unit as Object
+
+		
+	Description:
+		Applies a killed Eventhandler to garrison units to enable path finding
+		
+	Example:
+		nul = [_unit] spawn fw_fnc_garrisonKilledEH;
+
+*/
+
+// Parameter Init
+params ["_unit"];
+
+
+// Killed Eventhandler
+_unit addEventHandler ["Killed", {
+	// Parameter Init
+	params ["_dead"];
+
+	// Find Killer and create info string
+	private _killer = (_dead getVariable ["ace_medical_lastDamageSource", objNull]);
+
+	// Check if player
+	if (_killer in allPlayers && _killer distance2d _dead < SR_InstigatorDistance) then {
+		// Calculate number of AI to release
+		private _groupUnits = (units group _dead) call BIS_fnc_arrayShuffle;
+		private _releaseCount = floor (count _groupUnits * SR_ReleaseRatio) - {_x checkAIFeature "PATH"} count _groupUnits;
+		if (_releaseCount == 0) exitWith {};
+
+		// Filter all relevant units
+		private _releaseUnits =  [];
+		{
+			// Filter based on distance and disabled path finding
+			if (_x distance2D _dead < SR_ReleaseDistance && _x distance2d _killer < SR_InstigatorDistance && !(_x checkAIFeature "PATH")) then {
+				_releaseUnits pushBackUnique _x;
+				// Exit when enough units are pulled
+				if (count _releaseUnits == _releaseCount) exitWith {};
+ 			};
+		} forEach _groupUnits;
+
+		{
+			// Release units
+			_x enableAI "PATH";
+			_x setCombatMode "RED";
+
+			// Debug
+			if (SR_Debug) then { format ["%1 now has pathing enabled", _x] remoteExec ["systemChat", 0]; };
+		} forEach _releaseUnits;
+	};
+}];

--- a/Framework Files/7R/AI/Eventhandler/fn_garrisonKilledEH.sqf
+++ b/Framework Files/7R/AI/Eventhandler/fn_garrisonKilledEH.sqf
@@ -38,8 +38,8 @@ _unit addEventHandler ["Killed", {
 				_releaseUnits pushBackUnique _x;
  			};
 
-			// Remove EH - Global
-			[_x ,"Killed"] remoteExec ["removeAllEventHandlers", 0];
+			// Remove EH
+			_x removeAllEventHandlers "Killed";
 
 		} forEach _groupUnits;
 
@@ -50,7 +50,7 @@ _unit addEventHandler ["Killed", {
 			// Release units
 			_x enableAI "PATH";
 			_x setCombatMode "RED";
-
+			
 			// Debug
 			if (SR_Debug) then { format ["%1 now has pathing enabled", _x] remoteExec ["systemChat", 0]; };
 		} forEach _releaseUnits;

--- a/Framework Files/7R/Init/fn_frameworkInit.sqf
+++ b/Framework Files/7R/Init/fn_frameworkInit.sqf
@@ -22,7 +22,7 @@ if (isServer) then {
 };
 SR_InstigatorDistance = 20;
 SR_ReleaseDistance = 50;
-SR_ReleaseProbability = 0.33;
+SR_ReleaseRatio = 0.33;
 SR_SuspicionValue = 0;
 SR_SuspicionSpotted = -60;
 ArtilleryCallAmmo = 60;

--- a/Framework Files/7R/Init/fn_frameworkInit.sqf
+++ b/Framework Files/7R/Init/fn_frameworkInit.sqf
@@ -20,6 +20,9 @@ if (isServer) then {
 	SR_FF = "Friendly Fire:";
 	publicVariable "SR_FF";
 };
+SR_InstigatorDistance = 20;
+SR_ReleaseDistance = 50;
+SR_ReleaseProbability = 0.33;
 SR_SuspicionValue = 0;
 SR_SuspicionSpotted = -60;
 ArtilleryCallAmmo = 60;

--- a/Framework Files/7R/Init/fn_frameworkInit.sqf
+++ b/Framework Files/7R/Init/fn_frameworkInit.sqf
@@ -22,7 +22,8 @@ if (isServer) then {
 };
 SR_InstigatorDistance = 20;
 SR_ReleaseDistance = 50;
-SR_ReleaseRatio = 0.33;
+SR_MaxRatio = 0.67;
+SR_ReleaseProb = 0.4;
 SR_SuspicionValue = 0;
 SR_SuspicionSpotted = -60;
 ArtilleryCallAmmo = 60;

--- a/Framework Files/7R/Shared/functions.hpp
+++ b/Framework Files/7R/Shared/functions.hpp
@@ -160,6 +160,7 @@
 		class civKilledEH{};
 		class civPanicEH{};
 		class powKilledEH{};
+		class garrisonKilledEH{};
 	};
 	class Loadouts {
 		file = "7R\Loadouts";


### PR DESCRIPTION
Updates fnc_garrison.sqf to add a way for garrisoned AI to dynamically gain the ability to path when one of their nearby allies is killed.

Changes were only made on 'fnc_garrison.sqf' (i.e. all garrison spawned with "GARRISON" mode for spawnTemplate), and not fnc_garrisonZEI.sqf for two main reasons:
1. Incompatibility with ZEI garrison system, which could only be patched by modifying a few other files, wanted to avoid this just in case it would break something else.
2. Leaves mission makers the ability to spawn "fully static" garrisons.

Tested and verified on the server with up to 3 players. No locality issues.  