### PR TITLE
Implement Wave Respawn & Debrief Script Fixes

### DIFF
--- a/Framework Files/7R/Init/fn_frameworkInit.sqf
+++ b/Framework Files/7R/Init/fn_frameworkInit.sqf
@@ -34,7 +34,6 @@ UAVCallAmmo = 5;
 UAVFireMissionLock = false;
 ExfilReady = 0;
 ReifLock = false;
-SR_RespawnWave = false;
 SR_RespawnForce = false;
 SR_RespawnLock = false;
 phase = 0;

--- a/Framework Files/7R/Shared/fn_debrief.sqf
+++ b/Framework Files/7R/Shared/fn_debrief.sqf
@@ -78,3 +78,6 @@ player createDiaryRecord ["Debrief", ["Civilian Casulties", SR_CC]];
 player createDiaryRecord ["Debrief", ["War Crimes", SR_WC]];
 player createDiaryRecord ["Debrief", ["Friendly Fire", SR_FF]];
 player createDiaryRecord ["Debrief", ["Score", _scoreRecord]];
+
+// Force Respawn
+[] spawn fw_fnc_forceRespawn;

--- a/Framework Files/7R/Shared/fn_debrief.sqf
+++ b/Framework Files/7R/Shared/fn_debrief.sqf
@@ -21,23 +21,26 @@ if (phase == 9999) exitWith {
 // Message
 ["DEBRIEF STARTED", 1.5] spawn ace_common_fnc_displayTextStructured;
 
-// Server Only
-if (isServer) exitWith {
-	// Stop recording
-	["WMT_fnc_EndMission", _this] call CBA_fnc_localEvent;
-
+// Server only execute or HC if present
+if (isServer || (!hasInterface && !isDedicated)) then {
 	// Remove Hostiles
 	if (!_noDelete) then {
 		// Deny new spawns
 		SR_Unit_Cap = 0;
 		publicVariable "SR_Unit_Cap";
-		// Remove Hostiles
+		// Delete existing units
 		{
 			if ([SR_Side, (side _x)] call BIS_fnc_sideIsEnemy && !(_x setVariable ["SR_NoRemoval", false])) then {
 				deleteVehicle _x;
 			};
 		} forEach (allUnits-allPlayers);
 	};
+};
+
+// Server Only
+if (isServer) exitWith {
+	// Stop recording
+	["WMT_fnc_EndMission", _this] call CBA_fnc_localEvent;
 
 	// Set Variables
 	phase = 9999;

--- a/Framework Files/7R/Shared/fn_forceRespawn.sqf
+++ b/Framework Files/7R/Shared/fn_forceRespawn.sqf
@@ -1,0 +1,14 @@
+/*
+
+	Description:
+		Forces Respawn of all players in queue
+
+	Example:
+	[] spawn fw_fnc_forceRespawn;
+
+*/
+
+//Player only execute
+if !(hasInterface) exitWith {};
+
+setPlayerRespawnTime 1;

--- a/Framework Files/7R/Shared/fn_spawnMessage.sqf
+++ b/Framework Files/7R/Shared/fn_spawnMessage.sqf
@@ -4,12 +4,14 @@
 		Uses systemChat to announce new spawn wave
 
 	Example:
-	[] spawn fw_fnc_spawnMessage;
+	[player] spawn fw_fnc_spawnMessage;
 
 */
 
-//Server only execute
-if !(isServer) exitWith{};
+params ["_unit"];
+
+//Player only execute
+if !(local _unit) exitWith{};
 
 private _recentlyRun = missionNamespace getVariable ["spawnMessageSentRecently",false];
 

--- a/Framework Files/7R/Shared/fn_spawnMessage.sqf
+++ b/Framework Files/7R/Shared/fn_spawnMessage.sqf
@@ -1,0 +1,22 @@
+/*
+
+	Description:
+		Uses systemChat to announce new spawn wave
+
+	Example:
+	[] spawn fw_fnc_spawnMessage;
+
+*/
+
+if !(isServer) then {};
+
+private _recentlyRun = missionNamespace getVariable ["recentRunGlobal",false];
+
+sleep (0.5 + random 2); // random staggering to avoid running more than once
+
+if !(_recentlyRun) then {
+	missionNamespace setVariable ["recentRunGlobal",true]; // stop this from running more than once per wave
+	"Reinforcements have spawned" remoteExec ["systemChat", 0];
+	sleep 60; // generous sleep to allow for staggered spawns due to desync
+	missionNamespace setVariable ["recentRunGlobal",false];
+};

--- a/Framework Files/7R/Shared/fn_spawnMessage.sqf
+++ b/Framework Files/7R/Shared/fn_spawnMessage.sqf
@@ -8,7 +8,8 @@
 
 */
 
-if !(isServer) then {};
+//Server only execute
+if !(isServer) exitWith{};
 
 private _recentlyRun = missionNamespace getVariable ["spawnMessageSentRecently",false];
 

--- a/Framework Files/7R/Shared/fn_spawnMessage.sqf
+++ b/Framework Files/7R/Shared/fn_spawnMessage.sqf
@@ -10,13 +10,13 @@
 
 if !(isServer) then {};
 
-private _recentlyRun = missionNamespace getVariable ["recentRunGlobal",false];
+private _recentlyRun = missionNamespace getVariable ["spawnMessageSentRecently",false];
 
 sleep (0.5 + random 2); // random staggering to avoid running more than once
 
 if !(_recentlyRun) then {
-	missionNamespace setVariable ["recentRunGlobal",true]; // stop this from running more than once per wave
+	missionNamespace setVariable ["spawnMessageSentRecently",true]; // stop this from running more than once per wave
 	"Reinforcements have spawned" remoteExec ["systemChat", 0];
 	sleep 60; // generous sleep to allow for staggered spawns due to desync
-	missionNamespace setVariable ["recentRunGlobal",false];
+	missionNamespace setVariable ["spawnMessageSentRecently",false];
 };

--- a/Framework Files/7R/Shared/functions.hpp
+++ b/Framework Files/7R/Shared/functions.hpp
@@ -21,6 +21,8 @@
 		class info{};
 		class findLocation{};
 		class debrief{};
+		class forceRespawn{};
+		class spawnMessage{};
 	};
 	class template
 	{

--- a/Framework Files/7R/fn_systemInit.sqf
+++ b/Framework Files/7R/fn_systemInit.sqf
@@ -12,8 +12,6 @@ SR_Night = false; // Set to 'true' when the mission is played entirely at night.
 SR_Camo_Coef = 1; // For Night Missions, default: 1
 
 // Respawn Management
-SR_Respawn_Max = 600; // Maximum wait time for respawn.
-SR_Wave_Size = 2; // Minimum players needed to start a respawn wave.
 SR_Spawn_Height = 0; // Height above ground the player should respawn (for respawning on ships).
 
 /*

--- a/Framework Files/description.ext
+++ b/Framework Files/description.ext
@@ -1,3 +1,11 @@
+// respawn in waves
+respawnButton = 1;
+respawnTemplates[] = {"Wave","Spectator","Counter"};
+respawn = 3;
+respawndelay = 150; //Minimum respawn delay (in seconds), Maximum is 2x this value, Avg. respawn delay will be 1.5x this value
+respawnDialog = 0;
+respawnOnStart = 0;
+
 // enable Debug Console
 enableDebugConsole = 2;
 

--- a/Framework Files/onPlayerKilled.sqf
+++ b/Framework Files/onPlayerKilled.sqf
@@ -6,14 +6,17 @@ private _timeOfDeath = CBA_MissionTime;
 if (SR_RespawnLock) then {
 	// When locked block respawn
 	setPlayerRespawnTime 9999;
-} else {
-	// When open set max individual respawn time
-	setPlayerRespawnTime SR_Respawn_Max;
 };
 
 // Pilot excemption to bypass Queue
 private _pilot = (_unit getVariable ["SR_Class","Rifleman"]) isEqualTo "Pilot";
 if (_pilot && !SR_RespawnLock) then {
+	setPlayerRespawnTime 30;
+};
+
+// Force Instant Respawn
+if (SR_RespawnForce) then {
+	// When on, force instant respawn
 	setPlayerRespawnTime 3;
 };
 	
@@ -32,24 +35,5 @@ private _entry = "<br/>" + _nameDead + " [" +  _nameGroup + "] has been killed i
 SR_KIA = SR_KIA + "<br/>" + _nameDead + " [" + _nameGroup + "]" ;
 publicVariable "SR_KIA";
 
-// Check Wave Condition and exec Wave
-private _deathCount = ({isPlayer _x} count allDeadMen);
-if ((!SR_RespawnLock && _deathCount >= SR_Wave_Size) || (!SR_RespawnLock && _pilot)) then {
-	"Reinforcements Wave Started" remoteExec ["systemChat", 0];
-	// Start Wave
-	SR_RespawnWave = true;
-	publicVariable "SR_RespawnWave";
-	// Reset Wave
-	[{
-		SR_RespawnWave = false; 
-		publicVariable "SR_RespawnWave"; 
-		"Reinforcements Wave Ended" remoteExec ["systemChat", 0];
-	}, [], 60] call CBA_fnc_waitAndExecute;
-};
-
-// Execute when respawn wave present
-while {CBA_MissionTime - _timeOfDeath < playerRespawnTime} do {
-	if (SR_RespawnWave || SR_RespawnForce) then {
-		setPlayerRespawnTime 3;
-	};
-};
+// Respawn tracking variable
+_unit setVariable ["SR_hasDied",true];

--- a/Framework Files/onPlayerKilled.sqf
+++ b/Framework Files/onPlayerKilled.sqf
@@ -36,4 +36,4 @@ SR_KIA = SR_KIA + "<br/>" + _nameDead + " [" + _nameGroup + "]" ;
 publicVariable "SR_KIA";
 
 // Respawn tracking variable
-_unit setVariable ["SR_hasDied",true];
+_unit setVariable ["SR_HasDied",true];

--- a/Framework Files/onPlayerRespawn.sqf
+++ b/Framework Files/onPlayerRespawn.sqf
@@ -40,3 +40,10 @@ if (!isNull _oldUnit) then {
 	_str = (name _newUnit) + " has rejoined the Action.";
 	["CombatLog", ["REINF", _str]] call CBA_fnc_globalEvent; 
 };
+
+// Check Wave Condition and send wave spawn message
+private _pilot = (_newUnit getVariable ["SR_Class","Rifleman"]) isEqualTo "Pilot";
+private _hasDied = _oldUnit getVariable ["SR_hasDied",false];
+if ((!SR_RespawnLock && !_pilot) && _hasDied) then {
+	[] spawn fw_fnc_spawnMessage;
+};

--- a/Framework Files/onPlayerRespawn.sqf
+++ b/Framework Files/onPlayerRespawn.sqf
@@ -45,5 +45,5 @@ if (!isNull _oldUnit) then {
 private _pilot = (_newUnit getVariable ["SR_Class","Rifleman"]) isEqualTo "Pilot";
 private _hasDied = _oldUnit getVariable ["SR_HasDied",false];
 if ((!SR_RespawnLock && !_pilot) && _hasDied) then {
-	[] spawn fw_fnc_spawnMessage;
+	[_newUnit] spawn fw_fnc_spawnMessage;
 };

--- a/Framework Files/onPlayerRespawn.sqf
+++ b/Framework Files/onPlayerRespawn.sqf
@@ -43,7 +43,7 @@ if (!isNull _oldUnit) then {
 
 // Check Wave Condition and send wave spawn message
 private _pilot = (_newUnit getVariable ["SR_Class","Rifleman"]) isEqualTo "Pilot";
-private _hasDied = _oldUnit getVariable ["SR_hasDied",false];
+private _hasDied = _oldUnit getVariable ["SR_HasDied",false];
 if ((!SR_RespawnLock && !_pilot) && _hasDied) then {
 	[] spawn fw_fnc_spawnMessage;
 };


### PR DESCRIPTION
- Changes respawn method to BI-released wave respawn (respawn a wave every x minutes) to allow for less instant respawning, more spectating spawn, and encourage a more cautious playstyle
- Allows for a proper way to force respawn and does so automatically during the debrief script
- Fixes issue where debrief script was not deleting existing units because they were being handled by HC