### PR TITLE
Fix respawn message race condition

### DIFF
--- a/Framework Files/7R/Shared/fn_spawnMessage.sqf
+++ b/Framework Files/7R/Shared/fn_spawnMessage.sqf
@@ -13,9 +13,9 @@ params ["_unit"];
 //Player only execute
 if !(local _unit) exitWith{};
 
-private _recentlyRun = missionNamespace getVariable ["spawnMessageSentRecently",false];
-
 sleep (0.5 + random 2); // random staggering to avoid running more than once
+
+private _recentlyRun = missionNamespace getVariable ["spawnMessageSentRecently",false];
 
 if !(_recentlyRun) then {
 	missionNamespace setVariable ["spawnMessageSentRecently",true]; // stop this from running more than once per wave

--- a/Framework Files/7R/fn_systemInit.sqf
+++ b/Framework Files/7R/fn_systemInit.sqf
@@ -12,7 +12,7 @@ SR_Night = false; // Set to 'true' when the mission is played entirely at night.
 SR_Camo_Coef = 1; // For Night Missions, default: 1
 
 // Respawn Management
-SR_Spawn_Height = 0; // Height above ground the player should respawn (for respawning on ships).
+SR_Spawn_Height = 0; // Height above ground the player should respawn (for respawning on ships). (check height in editor with: hint format ["%1", (getPosASL player) select 2])
 
 /*
 	Available supply boxes.


### PR DESCRIPTION
Fixed respawn message race condition that made it so that if multiple players with relatively low ping/little desync to the server spawned together, each would schedule a message. Moved the global variable retrieval to occur after the random sleep, which should minimize the probability that this occurs.