### PR TITLE
Combine Echo and Lima loadouts in loadouts box

### DIFF
--- a/Sample Missions/[7R]Loadouts_Showcase.Altis/loadouts/MODERN/T1_BAF/T1_BAF_SAS/_uniforms_box.sqf
+++ b/Sample Missions/[7R]Loadouts_Showcase.Altis/loadouts/MODERN/T1_BAF/T1_BAF_SAS/_uniforms_box.sqf
@@ -39,18 +39,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\MODERN\T1_BAF\T1_BAF_SAS\baf_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\MODERN\T1_BAF\T1_BAF_SAS\baf_e_rifleman.sqf"],
-		["Echo AR", "loadouts\MODERN\T1_BAF\T1_BAF_SAS\baf_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\MODERN\T1_BAF\T1_BAF_SAS\baf_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\MODERN\T1_BAF\T1_BAF_SAS\baf_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\MODERN\T1_BAF\T1_BAF_SAS\baf_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\MODERN\T1_BAF\T1_BAF_SAS\baf_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\MODERN\T1_BAF\T1_BAF_SAS\baf_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\MODERN\T1_BAF\T1_BAF_SAS\baf_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\MODERN\T1_BAF\T1_BAF_SAS\baf_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\MODERN\T1_BAF\T1_BAF_SAS\baf_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\MODERN\T1_BAF\T1_BAF_SAS\baf_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\MODERN\T1_BAF\T1_BAF_SAS\baf_e_rifleman.sqf"],
+		["Support AR", "loadouts\MODERN\T1_BAF\T1_BAF_SAS\baf_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\MODERN\T1_BAF\T1_BAF_SAS\baf_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\MODERN\T1_BAF\T1_BAF_SAS\baf_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\MODERN\T1_BAF\T1_BAF_SAS\baf_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\MODERN\T1_BAF\T1_BAF_SAS\baf_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\MODERN\T1_BAF\T1_BAF_SAS\baf_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\MODERN\T1_BAF\T1_BAF_SAS\baf_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\MODERN\T1_BAF\T1_BAF_SAS\baf_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\MODERN\T1_BAF\T1_BAF_SAS\baf_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\MODERN\T1_BAF\T1_BAF_SAS\baf_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -70,11 +70,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\MODERN\T1_BAF\T1_BAF_SAS\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\MODERN\T1_BAF\T1_BAF_SAS\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\MODERN\T1_BAF\T1_BAF_SAS\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\MODERN\T1_BAF\T1_BAF_SAS\baf_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\MODERN\T1_BAF\T1_BAF_SAS\baf_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/Sample Missions/[7R]Loadouts_Showcase.Altis/loadouts/MODERN/T1_BAF/T1_BAF_SBS/_uniforms_box.sqf
+++ b/Sample Missions/[7R]Loadouts_Showcase.Altis/loadouts/MODERN/T1_BAF/T1_BAF_SBS/_uniforms_box.sqf
@@ -39,18 +39,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\MODERN\T1_BAF\T1_BAF_SBS\baf_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\MODERN\T1_BAF\T1_BAF_SBS\baf_e_rifleman.sqf"],
-		["Echo AR", "loadouts\MODERN\T1_BAF\T1_BAF_SBS\baf_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\MODERN\T1_BAF\T1_BAF_SBS\baf_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\MODERN\T1_BAF\T1_BAF_SBS\baf_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\MODERN\T1_BAF\T1_BAF_SBS\baf_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\MODERN\T1_BAF\T1_BAF_SBS\baf_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\MODERN\T1_BAF\T1_BAF_SBS\baf_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\MODERN\T1_BAF\T1_BAF_SBS\baf_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\MODERN\T1_BAF\T1_BAF_SBS\baf_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\MODERN\T1_BAF\T1_BAF_SBS\baf_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\MODERN\T1_BAF\T1_BAF_SBS\baf_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\MODERN\T1_BAF\T1_BAF_SBS\baf_e_rifleman.sqf"],
+		["Support AR", "loadouts\MODERN\T1_BAF\T1_BAF_SBS\baf_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\MODERN\T1_BAF\T1_BAF_SBS\baf_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\MODERN\T1_BAF\T1_BAF_SBS\baf_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\MODERN\T1_BAF\T1_BAF_SBS\baf_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\MODERN\T1_BAF\T1_BAF_SBS\baf_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\MODERN\T1_BAF\T1_BAF_SBS\baf_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\MODERN\T1_BAF\T1_BAF_SBS\baf_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\MODERN\T1_BAF\T1_BAF_SBS\baf_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\MODERN\T1_BAF\T1_BAF_SBS\baf_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\MODERN\T1_BAF\T1_BAF_SBS\baf_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -70,11 +70,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\MODERN\T1_BAF\T1_BAF_SBS\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\MODERN\T1_BAF\T1_BAF_SBS\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\MODERN\T1_BAF\T1_BAF_SBS\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\MODERN\T1_BAF\T1_BAF_SBS\baf_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\MODERN\T1_BAF\T1_BAF_SBS\baf_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/Sample Missions/[7R]Loadouts_Showcase.Altis/loadouts/MODERN/T1_US_DEVGRU/T1_US_DEVGRU_A/_uniforms_box.sqf
+++ b/Sample Missions/[7R]Loadouts_Showcase.Altis/loadouts/MODERN/T1_US_DEVGRU/T1_US_DEVGRU_A/_uniforms_box.sqf
@@ -38,18 +38,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_A\us_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_A\us_e_rifleman.sqf"],
-		["Echo AR", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_A\us_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_A\us_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_A\us_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_A\us_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_A\us_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_A\us_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_A\us_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_A\us_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_A\us_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_A\us_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_A\us_e_rifleman.sqf"],
+		["Support AR", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_A\us_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_A\us_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_A\us_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_A\us_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_A\us_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_A\us_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_A\us_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_A\us_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_A\us_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_A\us_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -69,11 +69,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_A\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_A\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_A\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_A\us_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_A\us_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/Sample Missions/[7R]Loadouts_Showcase.Altis/loadouts/MODERN/T1_US_DEVGRU/T1_US_DEVGRU_BO/_uniforms_box.sqf
+++ b/Sample Missions/[7R]Loadouts_Showcase.Altis/loadouts/MODERN/T1_US_DEVGRU/T1_US_DEVGRU_BO/_uniforms_box.sqf
@@ -38,18 +38,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_BO\us_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_BO\us_e_rifleman.sqf"],
-		["Echo AR", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_BO\us_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_BO\us_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_BO\us_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_BO\us_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_BO\us_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_BO\us_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_BO\us_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_BO\us_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_BO\us_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_BO\us_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_BO\us_e_rifleman.sqf"],
+		["Support AR", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_BO\us_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_BO\us_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_BO\us_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_BO\us_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_BO\us_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_BO\us_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_BO\us_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_BO\us_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_BO\us_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_BO\us_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -69,11 +69,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_BO\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_BO\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_BO\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_BO\us_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_BO\us_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/Sample Missions/[7R]Loadouts_Showcase.Altis/loadouts/MODERN/T1_US_DEVGRU/T1_US_DEVGRU_D/_uniforms_box.sqf
+++ b/Sample Missions/[7R]Loadouts_Showcase.Altis/loadouts/MODERN/T1_US_DEVGRU/T1_US_DEVGRU_D/_uniforms_box.sqf
@@ -38,18 +38,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_D\us_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_D\us_e_rifleman.sqf"],
-		["Echo AR", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_D\us_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_D\us_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_D\us_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_D\us_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_D\us_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_D\us_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_D\us_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_D\us_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_D\us_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_D\us_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_D\us_e_rifleman.sqf"],
+		["Support AR", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_D\us_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_D\us_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_D\us_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_D\us_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_D\us_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_D\us_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_D\us_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_D\us_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_D\us_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_D\us_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -69,11 +69,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_D\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_D\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_D\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_D\us_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_D\us_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/Sample Missions/[7R]Loadouts_Showcase.Altis/loadouts/MODERN/T1_US_DEVGRU/T1_US_DEVGRU_WD/_uniforms_box.sqf
+++ b/Sample Missions/[7R]Loadouts_Showcase.Altis/loadouts/MODERN/T1_US_DEVGRU/T1_US_DEVGRU_WD/_uniforms_box.sqf
@@ -38,18 +38,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_WD\us_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_WD\us_e_rifleman.sqf"],
-		["Echo AR", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_WD\us_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_WD\us_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_WD\us_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_WD\us_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_WD\us_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_WD\us_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_WD\us_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_WD\us_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_WD\us_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_WD\us_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_WD\us_e_rifleman.sqf"],
+		["Support AR", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_WD\us_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_WD\us_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_WD\us_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_WD\us_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_WD\us_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_WD\us_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_WD\us_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_WD\us_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_WD\us_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_WD\us_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -69,11 +69,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_WD\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_WD\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_WD\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_WD\us_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\MODERN\T1_US_DEVGRU\T1_US_DEVGRU_WD\us_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/Sample Missions/[7R]Loadouts_Showcase.Altis/loadouts/MODERN/T1_US_Green_Berets/_uniforms_box.sqf
+++ b/Sample Missions/[7R]Loadouts_Showcase.Altis/loadouts/MODERN/T1_US_Green_Berets/_uniforms_box.sqf
@@ -38,18 +38,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\MODERN\T1_US_Green_berets\us_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\MODERN\T1_US_Green_berets\us_e_rifleman.sqf"],
-		["Echo AR", "loadouts\MODERN\T1_US_Green_berets\us_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\MODERN\T1_US_Green_berets\us_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\MODERN\T1_US_Green_berets\us_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\MODERN\T1_US_Green_berets\us_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\MODERN\T1_US_Green_berets\us_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\MODERN\T1_US_Green_berets\us_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\MODERN\T1_US_Green_berets\us_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\MODERN\T1_US_Green_berets\us_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\MODERN\T1_US_Green_berets\us_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\MODERN\T1_US_Green_berets\us_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\MODERN\T1_US_Green_berets\us_e_rifleman.sqf"],
+		["Support AR", "loadouts\MODERN\T1_US_Green_berets\us_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\MODERN\T1_US_Green_berets\us_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\MODERN\T1_US_Green_berets\us_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\MODERN\T1_US_Green_berets\us_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\MODERN\T1_US_Green_berets\us_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\MODERN\T1_US_Green_berets\us_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\MODERN\T1_US_Green_berets\us_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\MODERN\T1_US_Green_berets\us_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\MODERN\T1_US_Green_berets\us_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\MODERN\T1_US_Green_berets\us_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -69,11 +69,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\MODERN\T1_US_Green_berets\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\MODERN\T1_US_Green_berets\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\MODERN\T1_US_Green_berets\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\MODERN\T1_US_Green_berets\us_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\MODERN\T1_US_Green_berets\us_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/Sample Missions/[7R]Loadouts_Showcase.Altis/loadouts/MODERN/T2_CDF_Airborne/_uniforms_box.sqf
+++ b/Sample Missions/[7R]Loadouts_Showcase.Altis/loadouts/MODERN/T2_CDF_Airborne/_uniforms_box.sqf
@@ -39,18 +39,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\MODERN\T2_CDF_Airborne\cdf_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\MODERN\T2_CDF_Airborne\cdf_e_rifleman.sqf"],
-		["Echo AR", "loadouts\MODERN\T2_CDF_Airborne\cdf_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\MODERN\T2_CDF_Airborne\cdf_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\MODERN\T2_CDF_Airborne\cdf_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\MODERN\T2_CDF_Airborne\cdf_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\MODERN\T2_CDF_Airborne\cdf_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\MODERN\T2_CDF_Airborne\cdf_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\MODERN\T2_CDF_Airborne\cdf_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\MODERN\T2_CDF_Airborne\cdf_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\MODERN\T2_CDF_Airborne\cdf_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\MODERN\T2_CDF_Airborne\cdf_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\MODERN\T2_CDF_Airborne\cdf_e_rifleman.sqf"],
+		["Support AR", "loadouts\MODERN\T2_CDF_Airborne\cdf_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\MODERN\T2_CDF_Airborne\cdf_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\MODERN\T2_CDF_Airborne\cdf_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\MODERN\T2_CDF_Airborne\cdf_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\MODERN\T2_CDF_Airborne\cdf_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\MODERN\T2_CDF_Airborne\cdf_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\MODERN\T2_CDF_Airborne\cdf_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\MODERN\T2_CDF_Airborne\cdf_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\MODERN\T2_CDF_Airborne\cdf_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\MODERN\T2_CDF_Airborne\cdf_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -70,11 +70,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\MODERN\T2_CDF_Airborne\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\MODERN\T2_CDF_Airborne\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\MODERN\T2_CDF_Airborne\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\MODERN\T2_CDF_Airborne\cdf_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\MODERN\T2_CDF_Airborne\cdf_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/Sample Missions/[7R]Loadouts_Showcase.Altis/loadouts/MODERN/T2_ESP_GOE/_uniforms_box.sqf
+++ b/Sample Missions/[7R]Loadouts_Showcase.Altis/loadouts/MODERN/T2_ESP_GOE/_uniforms_box.sqf
@@ -38,18 +38,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\MODERN\T2_ESP_GOE\esp_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\MODERN\T2_ESP_GOE\esp_e_rifleman.sqf"],
-		["Echo AR", "loadouts\MODERN\T2_ESP_GOE\esp_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\MODERN\T2_ESP_GOE\esp_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\MODERN\T2_ESP_GOE\esp_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\MODERN\T2_ESP_GOE\esp_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\MODERN\T2_ESP_GOE\esp_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\MODERN\T2_ESP_GOE\esp_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\MODERN\T2_ESP_GOE\esp_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\MODERN\T2_ESP_GOE\esp_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\MODERN\T2_ESP_GOE\esp_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\MODERN\T2_ESP_GOE\esp_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\MODERN\T2_ESP_GOE\esp_e_rifleman.sqf"],
+		["Support AR", "loadouts\MODERN\T2_ESP_GOE\esp_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\MODERN\T2_ESP_GOE\esp_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\MODERN\T2_ESP_GOE\esp_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\MODERN\T2_ESP_GOE\esp_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\MODERN\T2_ESP_GOE\esp_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\MODERN\T2_ESP_GOE\esp_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\MODERN\T2_ESP_GOE\esp_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\MODERN\T2_ESP_GOE\esp_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\MODERN\T2_ESP_GOE\esp_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\MODERN\T2_ESP_GOE\esp_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -69,11 +69,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\MODERN\T2_ESP_GOE\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\MODERN\T2_ESP_GOE\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\MODERN\T2_ESP_GOE\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\MODERN\T2_ESP_GOE\esp_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\MODERN\T2_ESP_GOE\esp_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/Sample Missions/[7R]Loadouts_Showcase.Altis/loadouts/MODERN/T2_NATO/_uniforms_box.sqf
+++ b/Sample Missions/[7R]Loadouts_Showcase.Altis/loadouts/MODERN/T2_NATO/_uniforms_box.sqf
@@ -39,18 +39,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\MODERN\T2_NATO\nato_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\MODERN\T2_NATO\nato_e_rifleman.sqf"],
-		["Echo AR", "loadouts\MODERN\T2_NATO\nato_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\MODERN\T2_NATO\nato_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\MODERN\T2_NATO\nato_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\MODERN\T2_NATO\nato_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\MODERN\T2_NATO\nato_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\MODERN\T2_NATO\nato_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\MODERN\T2_NATO\nato_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\MODERN\T2_NATO\nato_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\MODERN\T2_NATO\nato_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\MODERN\T2_NATO\nato_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\MODERN\T2_NATO\nato_e_rifleman.sqf"],
+		["Support AR", "loadouts\MODERN\T2_NATO\nato_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\MODERN\T2_NATO\nato_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\MODERN\T2_NATO\nato_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\MODERN\T2_NATO\nato_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\MODERN\T2_NATO\nato_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\MODERN\T2_NATO\nato_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\MODERN\T2_NATO\nato_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\MODERN\T2_NATO\nato_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\MODERN\T2_NATO\nato_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\MODERN\T2_NATO\nato_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -70,11 +70,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\MODERN\T2_NATO\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\MODERN\T2_NATO\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\MODERN\T2_NATO\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\MODERN\T2_NATO\nato_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\MODERN\T2_NATO\nato_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/Sample Missions/[7R]Loadouts_Showcase.Altis/loadouts/MODERN/T2_US_75th_Rangers/_uniforms_box.sqf
+++ b/Sample Missions/[7R]Loadouts_Showcase.Altis/loadouts/MODERN/T2_US_75th_Rangers/_uniforms_box.sqf
@@ -38,18 +38,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\MODERN\T2_US_75th_Rangers\us_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\MODERN\T2_US_75th_Rangers\us_e_rifleman.sqf"],
-		["Echo AR", "loadouts\MODERN\T2_US_75th_Rangers\us_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\MODERN\T2_US_75th_Rangers\us_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\MODERN\T2_US_75th_Rangers\us_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\MODERN\T2_US_75th_Rangers\us_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\MODERN\T2_US_75th_Rangers\us_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\MODERN\T2_US_75th_Rangers\us_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\MODERN\T2_US_75th_Rangers\us_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\MODERN\T2_US_75th_Rangers\us_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\MODERN\T2_US_75th_Rangers\us_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\MODERN\T2_US_75th_Rangers\us_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\MODERN\T2_US_75th_Rangers\us_e_rifleman.sqf"],
+		["Support AR", "loadouts\MODERN\T2_US_75th_Rangers\us_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\MODERN\T2_US_75th_Rangers\us_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\MODERN\T2_US_75th_Rangers\us_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\MODERN\T2_US_75th_Rangers\us_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\MODERN\T2_US_75th_Rangers\us_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\MODERN\T2_US_75th_Rangers\us_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\MODERN\T2_US_75th_Rangers\us_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\MODERN\T2_US_75th_Rangers\us_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\MODERN\T2_US_75th_Rangers\us_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\MODERN\T2_US_75th_Rangers\us_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -69,11 +69,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\MODERN\T2_US_75th_Rangers\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\MODERN\T2_US_75th_Rangers\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\MODERN\T2_US_75th_Rangers\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\MODERN\T2_US_75th_Rangers\us_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\MODERN\T2_US_75th_Rangers\us_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/Sample Missions/[7R]Loadouts_Showcase.Altis/loadouts/MODERN/T2_US_MARSOC/_uniforms_box.sqf
+++ b/Sample Missions/[7R]Loadouts_Showcase.Altis/loadouts/MODERN/T2_US_MARSOC/_uniforms_box.sqf
@@ -38,18 +38,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\MODERN\T2_US_MARSOC\us_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\MODERN\T2_US_MARSOC\us_e_rifleman.sqf"],
-		["Echo AR", "loadouts\MODERN\T2_US_MARSOC\us_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\MODERN\T2_US_MARSOC\us_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\MODERN\T2_US_MARSOC\us_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\MODERN\T2_US_MARSOC\us_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\MODERN\T2_US_MARSOC\us_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\MODERN\T2_US_MARSOC\us_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\MODERN\T2_US_MARSOC\us_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\MODERN\T2_US_MARSOC\us_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\MODERN\T2_US_MARSOC\us_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\MODERN\T2_US_MARSOC\us_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\MODERN\T2_US_MARSOC\us_e_rifleman.sqf"],
+		["Support AR", "loadouts\MODERN\T2_US_MARSOC\us_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\MODERN\T2_US_MARSOC\us_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\MODERN\T2_US_MARSOC\us_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\MODERN\T2_US_MARSOC\us_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\MODERN\T2_US_MARSOC\us_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\MODERN\T2_US_MARSOC\us_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\MODERN\T2_US_MARSOC\us_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\MODERN\T2_US_MARSOC\us_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\MODERN\T2_US_MARSOC\us_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\MODERN\T2_US_MARSOC\us_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -69,11 +69,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\MODERN\T2_US_MARSOC\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\MODERN\T2_US_MARSOC\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\MODERN\T2_US_MARSOC\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\MODERN\T2_US_MARSOC\us_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\MODERN\T2_US_MARSOC\us_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/Sample Missions/[7R]Loadouts_Showcase.Altis/loadouts/MODERN/T2_US_MEU/T2_US_MEU_D/_uniforms_box.sqf
+++ b/Sample Missions/[7R]Loadouts_Showcase.Altis/loadouts/MODERN/T2_US_MEU/T2_US_MEU_D/_uniforms_box.sqf
@@ -38,18 +38,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\MODERN\T2_US_MEU\T2_US_MEU_D\us_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\MODERN\T2_US_MEU\T2_US_MEU_D\us_e_rifleman.sqf"],
-		["Echo AR", "loadouts\MODERN\T2_US_MEU\T2_US_MEU_D\us_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\MODERN\T2_US_MEU\T2_US_MEU_D\us_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\MODERN\T2_US_MEU\T2_US_MEU_D\us_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\MODERN\T2_US_MEU\T2_US_MEU_D\us_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\MODERN\T2_US_MEU\T2_US_MEU_D\us_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\MODERN\T2_US_MEU\T2_US_MEU_D\us_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\MODERN\T2_US_MEU\T2_US_MEU_D\us_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\MODERN\T2_US_MEU\T2_US_MEU_D\us_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\MODERN\T2_US_MEU\T2_US_MEU_D\us_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\MODERN\T2_US_MEU\T2_US_MEU_D\us_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\MODERN\T2_US_MEU\T2_US_MEU_D\us_e_rifleman.sqf"],
+		["Support AR", "loadouts\MODERN\T2_US_MEU\T2_US_MEU_D\us_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\MODERN\T2_US_MEU\T2_US_MEU_D\us_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\MODERN\T2_US_MEU\T2_US_MEU_D\us_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\MODERN\T2_US_MEU\T2_US_MEU_D\us_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\MODERN\T2_US_MEU\T2_US_MEU_D\us_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\MODERN\T2_US_MEU\T2_US_MEU_D\us_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\MODERN\T2_US_MEU\T2_US_MEU_D\us_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\MODERN\T2_US_MEU\T2_US_MEU_D\us_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\MODERN\T2_US_MEU\T2_US_MEU_D\us_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\MODERN\T2_US_MEU\T2_US_MEU_D\us_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -69,11 +69,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\MODERN\T2_US_MEU\T2_US_MEU_D\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\MODERN\T2_US_MEU\T2_US_MEU_D\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\MODERN\T2_US_MEU\T2_US_MEU_D\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\MODERN\T2_US_MEU\T2_US_MEU_D\us_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\MODERN\T2_US_MEU\T2_US_MEU_D\us_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/Sample Missions/[7R]Loadouts_Showcase.Altis/loadouts/MODERN/T2_US_MEU/T2_US_MEU_WD/_uniforms_box.sqf
+++ b/Sample Missions/[7R]Loadouts_Showcase.Altis/loadouts/MODERN/T2_US_MEU/T2_US_MEU_WD/_uniforms_box.sqf
@@ -38,18 +38,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\MODERN\T2_US_MEU\T2_US_MEU_WD\us_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\MODERN\T2_US_MEU\T2_US_MEU_WD\us_e_rifleman.sqf"],
-		["Echo AR", "loadouts\MODERN\T2_US_MEU\T2_US_MEU_WD\us_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\MODERN\T2_US_MEU\T2_US_MEU_WD\us_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\MODERN\T2_US_MEU\T2_US_MEU_WD\us_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\MODERN\T2_US_MEU\T2_US_MEU_WD\us_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\MODERN\T2_US_MEU\T2_US_MEU_WD\us_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\MODERN\T2_US_MEU\T2_US_MEU_WD\us_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\MODERN\T2_US_MEU\T2_US_MEU_WD\us_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\MODERN\T2_US_MEU\T2_US_MEU_WD\us_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\MODERN\T2_US_MEU\T2_US_MEU_WD\us_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\MODERN\T2_US_MEU\T2_US_MEU_WD\us_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\MODERN\T2_US_MEU\T2_US_MEU_WD\us_e_rifleman.sqf"],
+		["Support AR", "loadouts\MODERN\T2_US_MEU\T2_US_MEU_WD\us_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\MODERN\T2_US_MEU\T2_US_MEU_WD\us_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\MODERN\T2_US_MEU\T2_US_MEU_WD\us_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\MODERN\T2_US_MEU\T2_US_MEU_WD\us_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\MODERN\T2_US_MEU\T2_US_MEU_WD\us_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\MODERN\T2_US_MEU\T2_US_MEU_WD\us_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\MODERN\T2_US_MEU\T2_US_MEU_WD\us_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\MODERN\T2_US_MEU\T2_US_MEU_WD\us_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\MODERN\T2_US_MEU\T2_US_MEU_WD\us_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\MODERN\T2_US_MEU\T2_US_MEU_WD\us_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -69,11 +69,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\MODERN\T2_US_MEU\T2_US_MEU_WD\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\MODERN\T2_US_MEU\T2_US_MEU_WD\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\MODERN\T2_US_MEU\T2_US_MEU_WD\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\MODERN\T2_US_MEU\T2_US_MEU_WD\us_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\MODERN\T2_US_MEU\T2_US_MEU_WD\us_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/Sample Missions/[7R]Loadouts_Showcase.Altis/loadouts/MODERN/T3_AAF_2020s/_uniforms_box.sqf
+++ b/Sample Missions/[7R]Loadouts_Showcase.Altis/loadouts/MODERN/T3_AAF_2020s/_uniforms_box.sqf
@@ -37,18 +37,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\MODERN\T3_AAF_2020s\aaf_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\MODERN\T3_AAF_2020s\aaf_e_rifleman.sqf"],
-		["Echo AR", "loadouts\MODERN\T3_AAF_2020s\aaf_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\MODERN\T3_AAF_2020s\aaf_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\MODERN\T3_AAF_2020s\aaf_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\MODERN\T3_AAF_2020s\aaf_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\MODERN\T3_AAF_2020s\aaf_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\MODERN\T3_AAF_2020s\aaf_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\MODERN\T3_AAF_2020s\aaf_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\MODERN\T3_AAF_2020s\aaf_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\MODERN\T3_AAF_2020s\aaf_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\MODERN\T3_AAF_2020s\aaf_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\MODERN\T3_AAF_2020s\aaf_e_rifleman.sqf"],
+		["Support AR", "loadouts\MODERN\T3_AAF_2020s\aaf_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\MODERN\T3_AAF_2020s\aaf_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\MODERN\T3_AAF_2020s\aaf_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\MODERN\T3_AAF_2020s\aaf_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\MODERN\T3_AAF_2020s\aaf_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\MODERN\T3_AAF_2020s\aaf_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\MODERN\T3_AAF_2020s\aaf_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\MODERN\T3_AAF_2020s\aaf_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\MODERN\T3_AAF_2020s\aaf_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\MODERN\T3_AAF_2020s\aaf_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -68,11 +68,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\MODERN\T3_AAF_2020s\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\MODERN\T3_AAF_2020s\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\MODERN\T3_AAF_2020s\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\MODERN\T3_AAF_2020s\aaf_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\MODERN\T3_AAF_2020s\aaf_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/Sample Missions/[7R]Loadouts_Showcase.Altis/loadouts/MODERN/T3_AUS_Army/_uniforms_box.sqf
+++ b/Sample Missions/[7R]Loadouts_Showcase.Altis/loadouts/MODERN/T3_AUS_Army/_uniforms_box.sqf
@@ -37,18 +37,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\MODERN\T3_AUS_Army\aus_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\MODERN\T3_AUS_Army\aus_e_rifleman.sqf"],
-		["Echo AR", "loadouts\MODERN\T3_AUS_Army\aus_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\MODERN\T3_AUS_Army\aus_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\MODERN\T3_AUS_Army\aus_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\MODERN\T3_AUS_Army\aus_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\MODERN\T3_AUS_Army\aus_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\MODERN\T3_AUS_Army\aus_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\MODERN\T3_AUS_Army\aus_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\MODERN\T3_AUS_Army\aus_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\MODERN\T3_AUS_Army\aus_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\MODERN\T3_AUS_Army\aus_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\MODERN\T3_AUS_Army\aus_e_rifleman.sqf"],
+		["Support AR", "loadouts\MODERN\T3_AUS_Army\aus_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\MODERN\T3_AUS_Army\aus_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\MODERN\T3_AUS_Army\aus_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\MODERN\T3_AUS_Army\aus_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\MODERN\T3_AUS_Army\aus_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\MODERN\T3_AUS_Army\aus_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\MODERN\T3_AUS_Army\aus_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\MODERN\T3_AUS_Army\aus_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\MODERN\T3_AUS_Army\aus_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\MODERN\T3_AUS_Army\aus_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -68,11 +68,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\MODERN\T3_AUS_Army\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\MODERN\T3_AUS_Army\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\MODERN\T3_AUS_Army\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\MODERN\T3_AUS_Army\aus_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\MODERN\T3_AUS_Army\aus_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/Sample Missions/[7R]Loadouts_Showcase.Altis/loadouts/MODERN/T3_BAF_2020s/_uniforms_box.sqf
+++ b/Sample Missions/[7R]Loadouts_Showcase.Altis/loadouts/MODERN/T3_BAF_2020s/_uniforms_box.sqf
@@ -36,18 +36,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\MODERN\T3_BAF_2020s\baf_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\MODERN\T3_BAF_2020s\baf_e_rifleman.sqf"],
-		["Echo AR", "loadouts\MODERN\T3_BAF_2020s\baf_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\MODERN\T3_BAF_2020s\baf_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\MODERN\T3_BAF_2020s\baf_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\MODERN\T3_BAF_2020s\baf_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\MODERN\T3_BAF_2020s\baf_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\MODERN\T3_BAF_2020s\baf_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\MODERN\T3_BAF_2020s\baf_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\MODERN\T3_BAF_2020s\baf_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\MODERN\T3_BAF_2020s\baf_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\MODERN\T3_BAF_2020s\baf_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\MODERN\T3_BAF_2020s\baf_e_rifleman.sqf"],
+		["Support AR", "loadouts\MODERN\T3_BAF_2020s\baf_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\MODERN\T3_BAF_2020s\baf_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\MODERN\T3_BAF_2020s\baf_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\MODERN\T3_BAF_2020s\baf_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\MODERN\T3_BAF_2020s\baf_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\MODERN\T3_BAF_2020s\baf_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\MODERN\T3_BAF_2020s\baf_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\MODERN\T3_BAF_2020s\baf_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\MODERN\T3_BAF_2020s\baf_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\MODERN\T3_BAF_2020s\baf_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -67,11 +67,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\MODERN\T3_BAF_2020s\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\MODERN\T3_BAF_2020s\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\MODERN\T3_BAF_2020s\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\MODERN\T3_BAF_2020s\baf_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\MODERN\T3_BAF_2020s\baf_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/Sample Missions/[7R]Loadouts_Showcase.Altis/loadouts/MODERN/T3_CDF_2020s/_uniforms_box.sqf
+++ b/Sample Missions/[7R]Loadouts_Showcase.Altis/loadouts/MODERN/T3_CDF_2020s/_uniforms_box.sqf
@@ -37,18 +37,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\MODERN\T3_CDF_2020s\cdf_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\MODERN\T3_CDF_2020s\cdf_e_rifleman.sqf"],
-		["Echo AR", "loadouts\MODERN\T3_CDF_2020s\cdf_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\MODERN\T3_CDF_2020s\cdf_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\MODERN\T3_CDF_2020s\cdf_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\MODERN\T3_CDF_2020s\cdf_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\MODERN\T3_CDF_2020s\cdf_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\MODERN\T3_CDF_2020s\cdf_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\MODERN\T3_CDF_2020s\cdf_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\MODERN\T3_CDF_2020s\cdf_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\MODERN\T3_CDF_2020s\cdf_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\MODERN\T3_CDF_2020s\cdf_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\MODERN\T3_CDF_2020s\cdf_e_rifleman.sqf"],
+		["Support AR", "loadouts\MODERN\T3_CDF_2020s\cdf_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\MODERN\T3_CDF_2020s\cdf_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\MODERN\T3_CDF_2020s\cdf_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\MODERN\T3_CDF_2020s\cdf_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\MODERN\T3_CDF_2020s\cdf_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\MODERN\T3_CDF_2020s\cdf_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\MODERN\T3_CDF_2020s\cdf_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\MODERN\T3_CDF_2020s\cdf_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\MODERN\T3_CDF_2020s\cdf_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\MODERN\T3_CDF_2020s\cdf_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -68,11 +68,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\MODERN\T3_CDF_2020s\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\MODERN\T3_CDF_2020s\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\MODERN\T3_CDF_2020s\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\MODERN\T3_CDF_2020s\cdf_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\MODERN\T3_CDF_2020s\cdf_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/Sample Missions/[7R]Loadouts_Showcase.Altis/loadouts/MODERN/T3_MidEast_Militia/_uniforms_box.sqf
+++ b/Sample Missions/[7R]Loadouts_Showcase.Altis/loadouts/MODERN/T3_MidEast_Militia/_uniforms_box.sqf
@@ -37,18 +37,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\MODERN\T3_MidEast_Militia\mem_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\MODERN\T3_MidEast_Militia\mem_e_rifleman.sqf"],
-		["Echo AR", "loadouts\MODERN\T3_MidEast_Militia\mem_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\MODERN\T3_MidEast_Militia\mem_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\MODERN\T3_MidEast_Militia\mem_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\MODERN\T3_MidEast_Militia\mem_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\MODERN\T3_MidEast_Militia\mem_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\MODERN\T3_MidEast_Militia\mem_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\MODERN\T3_MidEast_Militia\mem_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\MODERN\T3_MidEast_Militia\mem_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\MODERN\T3_MidEast_Militia\mem_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\MODERN\T3_MidEast_Militia\mem_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\MODERN\T3_MidEast_Militia\mem_e_rifleman.sqf"],
+		["Support AR", "loadouts\MODERN\T3_MidEast_Militia\mem_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\MODERN\T3_MidEast_Militia\mem_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\MODERN\T3_MidEast_Militia\mem_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\MODERN\T3_MidEast_Militia\mem_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\MODERN\T3_MidEast_Militia\mem_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\MODERN\T3_MidEast_Militia\mem_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\MODERN\T3_MidEast_Militia\mem_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\MODERN\T3_MidEast_Militia\mem_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\MODERN\T3_MidEast_Militia\mem_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\MODERN\T3_MidEast_Militia\mem_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -66,11 +66,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\MODERN\T3_MidEast_Militia\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\MODERN\T3_MidEast_Militia\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\MODERN\T3_MidEast_Militia\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\MODERN\T3_MidEast_Militia\mem_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\MODERN\T3_MidEast_Militia\mem_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/Sample Missions/[7R]Loadouts_Showcase.Altis/loadouts/MODERN/T3_US_Army/_uniforms_box.sqf
+++ b/Sample Missions/[7R]Loadouts_Showcase.Altis/loadouts/MODERN/T3_US_Army/_uniforms_box.sqf
@@ -37,18 +37,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\MODERN\T3_US_Army\us_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\MODERN\T3_US_Army\us_e_rifleman.sqf"],
-		["Echo AR", "loadouts\MODERN\T3_US_Army\us_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\MODERN\T3_US_Army\us_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\MODERN\T3_US_Army\us_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\MODERN\T3_US_Army\us_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\MODERN\T3_US_Army\us_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\MODERN\T3_US_Army\us_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\MODERN\T3_US_Army\us_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\MODERN\T3_US_Army\us_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\MODERN\T3_US_Army\us_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\MODERN\T3_US_Army\us_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\MODERN\T3_US_Army\us_e_rifleman.sqf"],
+		["Support AR", "loadouts\MODERN\T3_US_Army\us_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\MODERN\T3_US_Army\us_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\MODERN\T3_US_Army\us_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\MODERN\T3_US_Army\us_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\MODERN\T3_US_Army\us_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\MODERN\T3_US_Army\us_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\MODERN\T3_US_Army\us_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\MODERN\T3_US_Army\us_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\MODERN\T3_US_Army\us_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\MODERN\T3_US_Army\us_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -68,11 +68,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\MODERN\T3_US_Army\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\MODERN\T3_US_Army\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\MODERN\T3_US_Army\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\MODERN\T3_US_Army\us_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\MODERN\T3_US_Army\us_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/Sample Missions/[7R]Loadouts_Showcase.Altis/loadouts/MODERN/T3_US_Marines/_uniforms_box.sqf
+++ b/Sample Missions/[7R]Loadouts_Showcase.Altis/loadouts/MODERN/T3_US_Marines/_uniforms_box.sqf
@@ -37,18 +37,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\MODERN\T3_US_Marines\us_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\MODERN\T3_US_Marines\us_e_rifleman.sqf"],
-		["Echo AR", "loadouts\MODERN\T3_US_Marines\us_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\MODERN\T3_US_Marines\us_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\MODERN\T3_US_Marines\us_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\MODERN\T3_US_Marines\us_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\MODERN\T3_US_Marines\us_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\MODERN\T3_US_Marines\us_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\MODERN\T3_US_Marines\us_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\MODERN\T3_US_Marines\us_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\MODERN\T3_US_Marines\us_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\MODERN\T3_US_Marines\us_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\MODERN\T3_US_Marines\us_e_rifleman.sqf"],
+		["Support AR", "loadouts\MODERN\T3_US_Marines\us_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\MODERN\T3_US_Marines\us_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\MODERN\T3_US_Marines\us_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\MODERN\T3_US_Marines\us_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\MODERN\T3_US_Marines\us_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\MODERN\T3_US_Marines\us_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\MODERN\T3_US_Marines\us_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\MODERN\T3_US_Marines\us_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\MODERN\T3_US_Marines\us_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\MODERN\T3_US_Marines\us_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -68,11 +68,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\MODERN\T3_US_Marines\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\MODERN\T3_US_Marines\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\MODERN\T3_US_Marines\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\MODERN\T3_US_Marines\us_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\MODERN\T3_US_Marines\us_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/Sample Missions/[7R]Loadouts_Showcase.Altis/loadouts/MODERN/T3_Western_PMC/_uniforms_box.sqf
+++ b/Sample Missions/[7R]Loadouts_Showcase.Altis/loadouts/MODERN/T3_Western_PMC/_uniforms_box.sqf
@@ -39,18 +39,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\MODERN\T3_Western_PMC\pmc_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\MODERN\T3_Western_PMC\pmc_e_rifleman.sqf"],
-		["Echo AR", "loadouts\MODERN\T3_Western_PMC\pmc_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\MODERN\T3_Western_PMC\pmc_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\MODERN\T3_Western_PMC\pmc_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\MODERN\T3_Western_PMC\pmc_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\MODERN\T3_Western_PMC\pmc_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\MODERN\T3_Western_PMC\pmc_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\MODERN\T3_Western_PMC\pmc_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\MODERN\T3_Western_PMC\pmc_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\MODERN\T3_Western_PMC\pmc_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\MODERN\T3_Western_PMC\pmc_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\MODERN\T3_Western_PMC\pmc_e_rifleman.sqf"],
+		["Support AR", "loadouts\MODERN\T3_Western_PMC\pmc_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\MODERN\T3_Western_PMC\pmc_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\MODERN\T3_Western_PMC\pmc_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\MODERN\T3_Western_PMC\pmc_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\MODERN\T3_Western_PMC\pmc_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\MODERN\T3_Western_PMC\pmc_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\MODERN\T3_Western_PMC\pmc_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\MODERN\T3_Western_PMC\pmc_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\MODERN\T3_Western_PMC\pmc_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\MODERN\T3_Western_PMC\pmc_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -69,11 +69,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\MODERN\T3_Western_PMC\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\MODERN\T3_Western_PMC\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\MODERN\T3_Western_PMC\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\MODERN\T3_Western_PMC\pmc_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\MODERN\T3_Western_PMC\pmc_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/Sample Missions/[7R]Loadouts_Showcase.Altis/loadouts/RETRO/T3_AUS_RAR_2000s/_uniforms_box.sqf
+++ b/Sample Missions/[7R]Loadouts_Showcase.Altis/loadouts/RETRO/T3_AUS_RAR_2000s/_uniforms_box.sqf
@@ -37,18 +37,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\RETRO\T3_AUS_RAR_2000s\aus_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\RETRO\T3_AUS_RAR_2000s\aus_e_rifleman.sqf"],
-		["Echo AR", "loadouts\RETRO\T3_AUS_RAR_2000s\aus_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\RETRO\T3_AUS_RAR_2000s\aus_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\RETRO\T3_AUS_RAR_2000s\aus_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\RETRO\T3_AUS_RAR_2000s\aus_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\RETRO\T3_AUS_RAR_2000s\aus_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\RETRO\T3_AUS_RAR_2000s\aus_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\RETRO\T3_AUS_RAR_2000s\aus_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\RETRO\T3_AUS_RAR_2000s\aus_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\RETRO\T3_AUS_RAR_2000s\aus_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\RETRO\T3_AUS_RAR_2000s\aus_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\RETRO\T3_AUS_RAR_2000s\aus_e_rifleman.sqf"],
+		["Support AR", "loadouts\RETRO\T3_AUS_RAR_2000s\aus_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\RETRO\T3_AUS_RAR_2000s\aus_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\RETRO\T3_AUS_RAR_2000s\aus_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\RETRO\T3_AUS_RAR_2000s\aus_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\RETRO\T3_AUS_RAR_2000s\aus_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\RETRO\T3_AUS_RAR_2000s\aus_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\RETRO\T3_AUS_RAR_2000s\aus_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\RETRO\T3_AUS_RAR_2000s\aus_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\RETRO\T3_AUS_RAR_2000s\aus_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\RETRO\T3_AUS_RAR_2000s\aus_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -68,11 +68,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\RETRO\T3_AUS_RAR_2000s\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\RETRO\T3_AUS_RAR_2000s\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\RETRO\T3_AUS_RAR_2000s\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\RETRO\T3_AUS_RAR_2000s\aus_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\RETRO\T3_AUS_RAR_2000s\aus_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/Sample Missions/[7R]Loadouts_Showcase.Altis/loadouts/RETRO/T3_BAF_2000s/_uniforms_box.sqf
+++ b/Sample Missions/[7R]Loadouts_Showcase.Altis/loadouts/RETRO/T3_BAF_2000s/_uniforms_box.sqf
@@ -37,18 +37,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\RETRO\T3_BAF_2000s\baf_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\RETRO\T3_BAF_2000s\baf_e_rifleman.sqf"],
-		["Echo AR", "loadouts\RETRO\T3_BAF_2000s\baf_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\RETRO\T3_BAF_2000s\baf_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\RETRO\T3_BAF_2000s\baf_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\RETRO\T3_BAF_2000s\baf_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\RETRO\T3_BAF_2000s\baf_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\RETRO\T3_BAF_2000s\baf_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\RETRO\T3_BAF_2000s\baf_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\RETRO\T3_BAF_2000s\baf_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\RETRO\T3_BAF_2000s\baf_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\RETRO\T3_BAF_2000s\baf_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\RETRO\T3_BAF_2000s\baf_e_rifleman.sqf"],
+		["Support AR", "loadouts\RETRO\T3_BAF_2000s\baf_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\RETRO\T3_BAF_2000s\baf_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\RETRO\T3_BAF_2000s\baf_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\RETRO\T3_BAF_2000s\baf_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\RETRO\T3_BAF_2000s\baf_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\RETRO\T3_BAF_2000s\baf_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\RETRO\T3_BAF_2000s\baf_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\RETRO\T3_BAF_2000s\baf_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\RETRO\T3_BAF_2000s\baf_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\RETRO\T3_BAF_2000s\baf_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -67,11 +67,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\RETRO\T3_BAF_2000s\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\RETRO\T3_BAF_2000s\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\RETRO\T3_BAF_2000s\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\RETRO\T3_BAF_2000s\baf_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\RETRO\T3_BAF_2000s\baf_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/Sample Missions/[7R]Loadouts_Showcase.Altis/loadouts/RETRO/T3_CDF_90s_2000s/_uniforms_box.sqf
+++ b/Sample Missions/[7R]Loadouts_Showcase.Altis/loadouts/RETRO/T3_CDF_90s_2000s/_uniforms_box.sqf
@@ -37,16 +37,16 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\RETRO\T3_CDF_90s_2000s\cdf_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\RETRO\T3_CDF_90s_2000s\cdf_e_rifleman.sqf"],
-		["Echo AR", "loadouts\RETRO\T3_CDF_90s_2000s\cdf_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\RETRO\T3_CDF_90s_2000s\cdf_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\RETRO\T3_CDF_90s_2000s\cdf_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\RETRO\T3_CDF_90s_2000s\cdf_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\RETRO\T3_CDF_90s_2000s\cdf_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\RETRO\T3_CDF_90s_2000s\cdf_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\RETRO\T3_CDF_90s_2000s\cdf_e_morAsst.sqf"],
-		["Echo Driver", "loadouts\RETRO\T3_CDF_90s_2000s\cdf_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\RETRO\T3_CDF_90s_2000s\cdf_e_rifleman.sqf"],
+		["Support AR", "loadouts\RETRO\T3_CDF_90s_2000s\cdf_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\RETRO\T3_CDF_90s_2000s\cdf_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\RETRO\T3_CDF_90s_2000s\cdf_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\RETRO\T3_CDF_90s_2000s\cdf_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\RETRO\T3_CDF_90s_2000s\cdf_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\RETRO\T3_CDF_90s_2000s\cdf_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\RETRO\T3_CDF_90s_2000s\cdf_e_morAsst.sqf"],
+		["Support Driver", "loadouts\RETRO\T3_CDF_90s_2000s\cdf_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -64,11 +64,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\RETRO\T3_CDF_90s_2000s\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\RETRO\T3_CDF_90s_2000s\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\RETRO\T3_CDF_90s_2000s\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\RETRO\T3_CDF_90s_2000s\cdf_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\RETRO\T3_CDF_90s_2000s\cdf_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/Sample Missions/[7R]Loadouts_Showcase.Altis/loadouts/RETRO/T3_LPDF_80s_90s/_uniforms_box.sqf
+++ b/Sample Missions/[7R]Loadouts_Showcase.Altis/loadouts/RETRO/T3_LPDF_80s_90s/_uniforms_box.sqf
@@ -37,18 +37,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\RETRO\T3_LPDF_80s_90s\lpdf_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\RETRO\T3_LPDF_80s_90s\lpdf_e_rifleman.sqf"],
-		["Echo AR", "loadouts\RETRO\T3_LPDF_80s_90s\lpdf_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\RETRO\T3_LPDF_80s_90s\lpdf_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\RETRO\T3_LPDF_80s_90s\lpdf_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\RETRO\T3_LPDF_80s_90s\lpdf_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\RETRO\T3_LPDF_80s_90s\lpdf_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\RETRO\T3_LPDF_80s_90s\lpdf_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\RETRO\T3_LPDF_80s_90s\lpdf_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\RETRO\T3_LPDF_80s_90s\lpdf_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\RETRO\T3_LPDF_80s_90s\lpdf_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\RETRO\T3_LPDF_80s_90s\lpdf_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\RETRO\T3_LPDF_80s_90s\lpdf_e_rifleman.sqf"],
+		["Support AR", "loadouts\RETRO\T3_LPDF_80s_90s\lpdf_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\RETRO\T3_LPDF_80s_90s\lpdf_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\RETRO\T3_LPDF_80s_90s\lpdf_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\RETRO\T3_LPDF_80s_90s\lpdf_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\RETRO\T3_LPDF_80s_90s\lpdf_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\RETRO\T3_LPDF_80s_90s\lpdf_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\RETRO\T3_LPDF_80s_90s\lpdf_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\RETRO\T3_LPDF_80s_90s\lpdf_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\RETRO\T3_LPDF_80s_90s\lpdf_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\RETRO\T3_LPDF_80s_90s\lpdf_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -66,11 +66,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\RETRO\T3_LPDF_80s_90s\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\RETRO\T3_LPDF_80s_90s\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\RETRO\T3_LPDF_80s_90s\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\RETRO\T3_LPDF_80s_90s\lpdf_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\RETRO\T3_LPDF_80s_90s\lpdf_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/Sample Missions/[7R]Loadouts_Showcase.Altis/loadouts/RETRO/T3_USMC_2000s/_uniforms_box.sqf
+++ b/Sample Missions/[7R]Loadouts_Showcase.Altis/loadouts/RETRO/T3_USMC_2000s/_uniforms_box.sqf
@@ -37,18 +37,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\RETRO\T3_USMC_2000s\us_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\RETRO\T3_USMC_2000s\us_e_rifleman.sqf"],
-		["Echo AR", "loadouts\RETRO\T3_USMC_2000s\us_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\RETRO\T3_USMC_2000s\us_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\RETRO\T3_USMC_2000s\us_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\RETRO\T3_USMC_2000s\us_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\RETRO\T3_USMC_2000s\us_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\RETRO\T3_USMC_2000s\us_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\RETRO\T3_USMC_2000s\us_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\RETRO\T3_USMC_2000s\us_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\RETRO\T3_USMC_2000s\us_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\RETRO\T3_USMC_2000s\us_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\RETRO\T3_USMC_2000s\us_e_rifleman.sqf"],
+		["Support AR", "loadouts\RETRO\T3_USMC_2000s\us_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\RETRO\T3_USMC_2000s\us_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\RETRO\T3_USMC_2000s\us_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\RETRO\T3_USMC_2000s\us_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\RETRO\T3_USMC_2000s\us_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\RETRO\T3_USMC_2000s\us_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\RETRO\T3_USMC_2000s\us_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\RETRO\T3_USMC_2000s\us_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\RETRO\T3_USMC_2000s\us_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\RETRO\T3_USMC_2000s\us_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -68,11 +68,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\RETRO\T3_USMC_2000s\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\RETRO\T3_USMC_2000s\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\RETRO\T3_USMC_2000s\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\RETRO\T3_USMC_2000s\us_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\RETRO\T3_USMC_2000s\us_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/Sample Missions/[7R]Loadouts_Showcase.Altis/loadouts/RETRO/T3_US_Army_80s_90s/_uniforms_box.sqf
+++ b/Sample Missions/[7R]Loadouts_Showcase.Altis/loadouts/RETRO/T3_US_Army_80s_90s/_uniforms_box.sqf
@@ -37,18 +37,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\RETRO\T3_US_Army_80s_90s\us_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\RETRO\T3_US_Army_80s_90s\us_e_rifleman.sqf"],
-		["Echo AR", "loadouts\RETRO\T3_US_Army_80s_90s\us_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\RETRO\T3_US_Army_80s_90s\us_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\RETRO\T3_US_Army_80s_90s\us_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\RETRO\T3_US_Army_80s_90s\us_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\RETRO\T3_US_Army_80s_90s\us_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\RETRO\T3_US_Army_80s_90s\us_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\RETRO\T3_US_Army_80s_90s\us_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\RETRO\T3_US_Army_80s_90s\us_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\RETRO\T3_US_Army_80s_90s\us_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\RETRO\T3_US_Army_80s_90s\us_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\RETRO\T3_US_Army_80s_90s\us_e_rifleman.sqf"],
+		["Support AR", "loadouts\RETRO\T3_US_Army_80s_90s\us_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\RETRO\T3_US_Army_80s_90s\us_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\RETRO\T3_US_Army_80s_90s\us_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\RETRO\T3_US_Army_80s_90s\us_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\RETRO\T3_US_Army_80s_90s\us_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\RETRO\T3_US_Army_80s_90s\us_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\RETRO\T3_US_Army_80s_90s\us_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\RETRO\T3_US_Army_80s_90s\us_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\RETRO\T3_US_Army_80s_90s\us_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\RETRO\T3_US_Army_80s_90s\us_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -68,11 +68,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\RETRO\T3_US_Army_80s_90s\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\RETRO\T3_US_Army_80s_90s\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\RETRO\T3_US_Army_80s_90s\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\RETRO\T3_US_Army_80s_90s\us_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\RETRO\T3_US_Army_80s_90s\us_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/loadouts/MODERN/T1_BAF_SF/T1_BAF_SAS/_uniforms_box.sqf
+++ b/loadouts/MODERN/T1_BAF_SF/T1_BAF_SAS/_uniforms_box.sqf
@@ -39,18 +39,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\baf_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\baf_e_rifleman.sqf"],
-		["Echo AR", "loadouts\baf_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\baf_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\baf_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\baf_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\baf_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\baf_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\baf_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\baf_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\baf_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\baf_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\baf_e_rifleman.sqf"],
+		["Support AR", "loadouts\baf_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\baf_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\baf_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\baf_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\baf_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\baf_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\baf_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\baf_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\baf_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\baf_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -70,11 +70,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\baf_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\baf_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/loadouts/MODERN/T1_BAF_SF/T1_BAF_SBS/_uniforms_box.sqf
+++ b/loadouts/MODERN/T1_BAF_SF/T1_BAF_SBS/_uniforms_box.sqf
@@ -39,18 +39,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\baf_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\baf_e_rifleman.sqf"],
-		["Echo AR", "loadouts\baf_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\baf_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\baf_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\baf_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\baf_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\baf_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\baf_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\baf_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\baf_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\baf_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\baf_e_rifleman.sqf"],
+		["Support AR", "loadouts\baf_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\baf_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\baf_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\baf_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\baf_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\baf_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\baf_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\baf_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\baf_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\baf_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -70,11 +70,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\baf_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\baf_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/loadouts/MODERN/T1_BW_KSK/_uniforms_box.sqf
+++ b/loadouts/MODERN/T1_BW_KSK/_uniforms_box.sqf
@@ -38,18 +38,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\bw_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\bw_e_rifleman.sqf"],
-		["Echo AR", "loadouts\bw_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\bw_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\bw_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\bw_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\bw_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\bw_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\bw_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\bw_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\bw_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\bw_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\bw_e_rifleman.sqf"],
+		["Support AR", "loadouts\bw_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\bw_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\bw_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\bw_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\bw_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\bw_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\bw_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\bw_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\bw_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\bw_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -69,11 +69,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\bw_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\bw_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/loadouts/MODERN/T1_US_DEVGRU/T1_US_DEVGRU_A/_uniforms_box.sqf
+++ b/loadouts/MODERN/T1_US_DEVGRU/T1_US_DEVGRU_A/_uniforms_box.sqf
@@ -38,18 +38,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\us_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\us_e_rifleman.sqf"],
-		["Echo AR", "loadouts\us_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\us_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\us_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\us_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\us_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\us_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\us_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\us_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\us_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\us_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\us_e_rifleman.sqf"],
+		["Support AR", "loadouts\us_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\us_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\us_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\us_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\us_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\us_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\us_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\us_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\us_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\us_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -69,11 +69,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\us_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\us_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/loadouts/MODERN/T1_US_DEVGRU/T1_US_DEVGRU_BO/_uniforms_box.sqf
+++ b/loadouts/MODERN/T1_US_DEVGRU/T1_US_DEVGRU_BO/_uniforms_box.sqf
@@ -38,18 +38,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\us_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\us_e_rifleman.sqf"],
-		["Echo AR", "loadouts\us_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\us_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\us_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\us_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\us_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\us_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\us_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\us_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\us_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\us_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\us_e_rifleman.sqf"],
+		["Support AR", "loadouts\us_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\us_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\us_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\us_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\us_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\us_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\us_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\us_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\us_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\us_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -69,11 +69,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\us_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\us_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/loadouts/MODERN/T1_US_DEVGRU/T1_US_DEVGRU_D/_uniforms_box.sqf
+++ b/loadouts/MODERN/T1_US_DEVGRU/T1_US_DEVGRU_D/_uniforms_box.sqf
@@ -38,18 +38,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\us_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\us_e_rifleman.sqf"],
-		["Echo AR", "loadouts\us_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\us_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\us_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\us_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\us_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\us_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\us_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\us_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\us_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\us_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\us_e_rifleman.sqf"],
+		["Support AR", "loadouts\us_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\us_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\us_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\us_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\us_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\us_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\us_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\us_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\us_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\us_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -69,11 +69,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\us_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\us_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/loadouts/MODERN/T1_US_DEVGRU/T1_US_DEVGRU_WD/_uniforms_box.sqf
+++ b/loadouts/MODERN/T1_US_DEVGRU/T1_US_DEVGRU_WD/_uniforms_box.sqf
@@ -38,18 +38,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\us_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\us_e_rifleman.sqf"],
-		["Echo AR", "loadouts\us_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\us_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\us_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\us_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\us_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\us_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\us_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\us_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\us_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\us_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\us_e_rifleman.sqf"],
+		["Support AR", "loadouts\us_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\us_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\us_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\us_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\us_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\us_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\us_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\us_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\us_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\us_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -69,11 +69,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\us_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\us_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/loadouts/MODERN/T1_US_Green_Berets/_uniforms_box.sqf
+++ b/loadouts/MODERN/T1_US_Green_Berets/_uniforms_box.sqf
@@ -38,18 +38,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\us_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\us_e_rifleman.sqf"],
-		["Echo AR", "loadouts\us_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\us_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\us_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\us_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\us_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\us_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\us_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\us_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\us_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\us_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\us_e_rifleman.sqf"],
+		["Support AR", "loadouts\us_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\us_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\us_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\us_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\us_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\us_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\us_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\us_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\us_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\us_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -69,11 +69,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\us_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\us_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/loadouts/MODERN/T2_BAF_RMC(SOC)/_uniforms_box.sqf
+++ b/loadouts/MODERN/T2_BAF_RMC(SOC)/_uniforms_box.sqf
@@ -39,18 +39,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\baf_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\baf_e_rifleman.sqf"],
-		["Echo AR", "loadouts\baf_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\baf_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\baf_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\baf_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\baf_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\baf_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\baf_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\baf_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\baf_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\baf_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\baf_e_rifleman.sqf"],
+		["Support AR", "loadouts\baf_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\baf_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\baf_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\baf_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\baf_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\baf_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\baf_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\baf_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\baf_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\baf_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -70,11 +70,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\baf_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\baf_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/loadouts/MODERN/T2_BW_31st_Paratrooper/T2_BW_31st_Paratrooper_D/_uniforms_box.sqf
+++ b/loadouts/MODERN/T2_BW_31st_Paratrooper/T2_BW_31st_Paratrooper_D/_uniforms_box.sqf
@@ -38,18 +38,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\bw_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\bw_e_rifleman.sqf"],
-		["Echo AR", "loadouts\bw_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\bw_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\bw_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\bw_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\bw_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\bw_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\bw_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\bw_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\bw_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\bw_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\bw_e_rifleman.sqf"],
+		["Support AR", "loadouts\bw_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\bw_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\bw_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\bw_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\bw_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\bw_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\bw_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\bw_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\bw_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\bw_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -69,11 +69,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\bw_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\bw_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/loadouts/MODERN/T2_BW_31st_Paratrooper/T2_BW_31st_Paratrooper_WD/_uniforms_box.sqf
+++ b/loadouts/MODERN/T2_BW_31st_Paratrooper/T2_BW_31st_Paratrooper_WD/_uniforms_box.sqf
@@ -38,18 +38,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\bw_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\bw_e_rifleman.sqf"],
-		["Echo AR", "loadouts\bw_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\bw_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\bw_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\bw_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\bw_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\bw_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\bw_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\bw_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\bw_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\bw_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\bw_e_rifleman.sqf"],
+		["Support AR", "loadouts\bw_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\bw_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\bw_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\bw_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\bw_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\bw_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\bw_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\bw_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\bw_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\bw_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -69,11 +69,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\bw_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\bw_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/loadouts/MODERN/T2_CDF_Airborne/_uniforms_box.sqf
+++ b/loadouts/MODERN/T2_CDF_Airborne/_uniforms_box.sqf
@@ -39,18 +39,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\cdf_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\cdf_e_rifleman.sqf"],
-		["Echo AR", "loadouts\cdf_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\cdf_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\cdf_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\cdf_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\cdf_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\cdf_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\cdf_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\cdf_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\cdf_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\cdf_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\cdf_e_rifleman.sqf"],
+		["Support AR", "loadouts\cdf_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\cdf_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\cdf_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\cdf_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\cdf_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\cdf_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\cdf_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\cdf_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\cdf_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\cdf_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -70,11 +70,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\cdf_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\cdf_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/loadouts/MODERN/T2_FRA_13e_RDP/T2_FRA_13e_RDP_D/_uniforms_box.sqf
+++ b/loadouts/MODERN/T2_FRA_13e_RDP/T2_FRA_13e_RDP_D/_uniforms_box.sqf
@@ -38,18 +38,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\fra_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\fra_e_rifleman.sqf"],
-		["Echo AR", "loadouts\fra_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\fra_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\fra_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\fra_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\fra_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\fra_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\fra_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\fra_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\fra_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\fra_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\fra_e_rifleman.sqf"],
+		["Support AR", "loadouts\fra_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\fra_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\fra_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\fra_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\fra_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\fra_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\fra_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\fra_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\fra_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\fra_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -69,11 +69,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\fra_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\fra_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/loadouts/MODERN/T2_FRA_13e_RDP/T2_FRA_13e_RDP_WD/_uniforms_box.sqf
+++ b/loadouts/MODERN/T2_FRA_13e_RDP/T2_FRA_13e_RDP_WD/_uniforms_box.sqf
@@ -38,18 +38,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\fra_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\fra_e_rifleman.sqf"],
-		["Echo AR", "loadouts\fra_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\fra_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\fra_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\fra_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\fra_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\fra_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\fra_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\fra_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\fra_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\fra_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\fra_e_rifleman.sqf"],
+		["Support AR", "loadouts\fra_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\fra_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\fra_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\fra_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\fra_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\fra_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\fra_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\fra_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\fra_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\fra_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -69,11 +69,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\fra_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\fra_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/loadouts/MODERN/T2_NATO/T2_NATO_MTP/_uniforms_box.sqf
+++ b/loadouts/MODERN/T2_NATO/T2_NATO_MTP/_uniforms_box.sqf
@@ -39,18 +39,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\nato_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\nato_e_rifleman.sqf"],
-		["Echo AR", "loadouts\nato_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\nato_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\nato_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\nato_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\nato_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\nato_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\nato_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\nato_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\nato_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\nato_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\nato_e_rifleman.sqf"],
+		["Support AR", "loadouts\nato_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\nato_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\nato_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\nato_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\nato_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\nato_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\nato_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\nato_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\nato_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\nato_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -70,11 +70,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\nato_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\nato_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/loadouts/MODERN/T2_NATO/T2_NATO_Tropical/_uniforms_box.sqf
+++ b/loadouts/MODERN/T2_NATO/T2_NATO_Tropical/_uniforms_box.sqf
@@ -39,18 +39,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\nato_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\nato_e_rifleman.sqf"],
-		["Echo AR", "loadouts\nato_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\nato_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\nato_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\nato_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\nato_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\nato_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\nato_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\nato_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\nato_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\nato_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\nato_e_rifleman.sqf"],
+		["Support AR", "loadouts\nato_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\nato_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\nato_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\nato_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\nato_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\nato_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\nato_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\nato_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\nato_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\nato_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -70,11 +70,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\nato_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\nato_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/loadouts/MODERN/T2_NATO/T2_NATO_Woodland/_uniforms_box.sqf
+++ b/loadouts/MODERN/T2_NATO/T2_NATO_Woodland/_uniforms_box.sqf
@@ -39,18 +39,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\nato_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\nato_e_rifleman.sqf"],
-		["Echo AR", "loadouts\nato_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\nato_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\nato_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\nato_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\nato_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\nato_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\nato_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\nato_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\nato_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\nato_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\nato_e_rifleman.sqf"],
+		["Support AR", "loadouts\nato_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\nato_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\nato_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\nato_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\nato_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\nato_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\nato_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\nato_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\nato_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\nato_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -70,11 +70,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\nato_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\nato_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/loadouts/MODERN/T2_US_75th_Rangers/T2_US_75th_Rangers_OCP/_uniforms_box.sqf
+++ b/loadouts/MODERN/T2_US_75th_Rangers/T2_US_75th_Rangers_OCP/_uniforms_box.sqf
@@ -38,18 +38,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\us_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\us_e_rifleman.sqf"],
-		["Echo AR", "loadouts\us_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\us_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\us_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\us_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\us_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\us_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\us_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\us_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\us_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\us_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\us_e_rifleman.sqf"],
+		["Support AR", "loadouts\us_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\us_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\us_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\us_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\us_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\us_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\us_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\us_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\us_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\us_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -69,11 +69,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\us_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\us_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/loadouts/MODERN/T2_US_75th_Rangers/T2_US_75th_Rangers_OCP_Winter/_uniforms_box.sqf
+++ b/loadouts/MODERN/T2_US_75th_Rangers/T2_US_75th_Rangers_OCP_Winter/_uniforms_box.sqf
@@ -38,18 +38,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\us_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\us_e_rifleman.sqf"],
-		["Echo AR", "loadouts\us_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\us_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\us_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\us_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\us_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\us_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\us_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\us_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\us_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\us_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\us_e_rifleman.sqf"],
+		["Support AR", "loadouts\us_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\us_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\us_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\us_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\us_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\us_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\us_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\us_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\us_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\us_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -69,11 +69,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\us_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\us_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/loadouts/MODERN/T2_US_MARSOC/T2_US_MARSOC_D/_uniforms_box.sqf
+++ b/loadouts/MODERN/T2_US_MARSOC/T2_US_MARSOC_D/_uniforms_box.sqf
@@ -38,18 +38,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\us_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\us_e_rifleman.sqf"],
-		["Echo AR", "loadouts\us_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\us_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\us_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\us_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\us_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\us_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\us_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\us_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\us_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\us_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\us_e_rifleman.sqf"],
+		["Support AR", "loadouts\us_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\us_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\us_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\us_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\us_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\us_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\us_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\us_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\us_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\us_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -69,11 +69,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\us_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\us_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/loadouts/MODERN/T2_US_MARSOC/T2_US_MARSOC_WD/_uniforms_box.sqf
+++ b/loadouts/MODERN/T2_US_MARSOC/T2_US_MARSOC_WD/_uniforms_box.sqf
@@ -38,18 +38,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\us_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\us_e_rifleman.sqf"],
-		["Echo AR", "loadouts\us_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\us_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\us_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\us_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\us_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\us_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\us_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\us_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\us_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\us_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\us_e_rifleman.sqf"],
+		["Support AR", "loadouts\us_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\us_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\us_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\us_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\us_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\us_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\us_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\us_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\us_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\us_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -69,11 +69,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\us_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\us_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/loadouts/MODERN/T2_US_MEU(SOC)/T2_US_MEU(SOC)_D/_uniforms_box.sqf
+++ b/loadouts/MODERN/T2_US_MEU(SOC)/T2_US_MEU(SOC)_D/_uniforms_box.sqf
@@ -38,18 +38,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\us_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\us_e_rifleman.sqf"],
-		["Echo AR", "loadouts\us_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\us_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\us_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\us_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\us_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\us_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\us_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\us_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\us_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\us_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\us_e_rifleman.sqf"],
+		["Support AR", "loadouts\us_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\us_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\us_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\us_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\us_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\us_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\us_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\us_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\us_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\us_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -69,11 +69,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\us_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\us_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/loadouts/MODERN/T2_US_MEU(SOC)/T2_US_MEU(SOC)_W/_uniforms_box.sqf
+++ b/loadouts/MODERN/T2_US_MEU(SOC)/T2_US_MEU(SOC)_W/_uniforms_box.sqf
@@ -38,18 +38,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\us_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\us_e_rifleman.sqf"],
-		["Echo AR", "loadouts\us_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\us_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\us_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\us_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\us_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\us_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\us_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\us_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\us_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\us_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\us_e_rifleman.sqf"],
+		["Support AR", "loadouts\us_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\us_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\us_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\us_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\us_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\us_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\us_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\us_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\us_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\us_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -69,11 +69,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\us_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\us_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/loadouts/MODERN/T2_US_MEU(SOC)/T2_US_MEU(SOC)_WD/_uniforms_box.sqf
+++ b/loadouts/MODERN/T2_US_MEU(SOC)/T2_US_MEU(SOC)_WD/_uniforms_box.sqf
@@ -38,18 +38,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\us_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\us_e_rifleman.sqf"],
-		["Echo AR", "loadouts\us_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\us_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\us_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\us_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\us_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\us_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\us_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\us_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\us_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\us_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\us_e_rifleman.sqf"],
+		["Support AR", "loadouts\us_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\us_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\us_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\us_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\us_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\us_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\us_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\us_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\us_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\us_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -69,11 +69,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\us_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\us_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/loadouts/MODERN/T3_AAF_2020s/T3_AAF_2020s_BLUFOR/_uniforms_box.sqf
+++ b/loadouts/MODERN/T3_AAF_2020s/T3_AAF_2020s_BLUFOR/_uniforms_box.sqf
@@ -37,18 +37,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\aaf_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\aaf_e_rifleman.sqf"],
-		["Echo AR", "loadouts\aaf_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\aaf_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\aaf_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\aaf_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\aaf_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\aaf_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\aaf_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\aaf_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\aaf_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\aaf_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\aaf_e_rifleman.sqf"],
+		["Support AR", "loadouts\aaf_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\aaf_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\aaf_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\aaf_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\aaf_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\aaf_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\aaf_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\aaf_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\aaf_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\aaf_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -68,11 +68,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\aaf_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\aaf_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/loadouts/MODERN/T3_AAF_2020s/T3_AAF_2020s_OPFOR/_uniforms_box.sqf
+++ b/loadouts/MODERN/T3_AAF_2020s/T3_AAF_2020s_OPFOR/_uniforms_box.sqf
@@ -37,18 +37,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\aaf_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\aaf_e_rifleman.sqf"],
-		["Echo AR", "loadouts\aaf_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\aaf_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\aaf_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\aaf_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\aaf_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\aaf_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\aaf_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\aaf_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\aaf_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\aaf_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\aaf_e_rifleman.sqf"],
+		["Support AR", "loadouts\aaf_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\aaf_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\aaf_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\aaf_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\aaf_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\aaf_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\aaf_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\aaf_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\aaf_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\aaf_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -68,11 +68,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\aaf_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\aaf_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/loadouts/MODERN/T3_AUS_Army/_uniforms_box.sqf
+++ b/loadouts/MODERN/T3_AUS_Army/_uniforms_box.sqf
@@ -37,18 +37,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\aus_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\aus_e_rifleman.sqf"],
-		["Echo AR", "loadouts\aus_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\aus_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\aus_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\aus_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\aus_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\aus_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\aus_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\aus_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\aus_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\aus_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\aus_e_rifleman.sqf"],
+		["Support AR", "loadouts\aus_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\aus_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\aus_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\aus_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\aus_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\aus_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\aus_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\aus_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\aus_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\aus_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -68,11 +68,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\aus_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\aus_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/loadouts/MODERN/T3_BAF_2020s/T3_BAF_PARAS/_uniforms_box.sqf
+++ b/loadouts/MODERN/T3_BAF_2020s/T3_BAF_PARAS/_uniforms_box.sqf
@@ -38,18 +38,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\baf_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\baf_e_rifleman.sqf"],
-		["Echo AR", "loadouts\baf_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\baf_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\baf_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\baf_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\baf_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\baf_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\baf_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\baf_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\baf_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\baf_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\baf_e_rifleman.sqf"],
+		["Support AR", "loadouts\baf_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\baf_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\baf_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\baf_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\baf_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\baf_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\baf_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\baf_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\baf_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\baf_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -69,11 +69,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\baf_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\baf_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/loadouts/MODERN/T3_BAF_2020s/T3_BAF_RIFLES/_uniforms_box.sqf
+++ b/loadouts/MODERN/T3_BAF_2020s/T3_BAF_RIFLES/_uniforms_box.sqf
@@ -38,18 +38,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\baf_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\baf_e_rifleman.sqf"],
-		["Echo AR", "loadouts\baf_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\baf_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\baf_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\baf_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\baf_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\baf_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\baf_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\baf_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\baf_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\baf_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\baf_e_rifleman.sqf"],
+		["Support AR", "loadouts\baf_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\baf_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\baf_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\baf_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\baf_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\baf_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\baf_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\baf_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\baf_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\baf_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -69,11 +69,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\baf_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\baf_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/loadouts/MODERN/T3_BAF_2020s/T3_BAF_RMC/_uniforms_box.sqf
+++ b/loadouts/MODERN/T3_BAF_2020s/T3_BAF_RMC/_uniforms_box.sqf
@@ -38,18 +38,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\baf_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\baf_e_rifleman.sqf"],
-		["Echo AR", "loadouts\baf_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\baf_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\baf_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\baf_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\baf_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\baf_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\baf_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\baf_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\baf_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\baf_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\baf_e_rifleman.sqf"],
+		["Support AR", "loadouts\baf_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\baf_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\baf_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\baf_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\baf_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\baf_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\baf_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\baf_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\baf_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\baf_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -69,11 +69,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\baf_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\baf_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/loadouts/MODERN/T3_BAF_2020s/T3_BAF_SCOTS/_uniforms_box.sqf
+++ b/loadouts/MODERN/T3_BAF_2020s/T3_BAF_SCOTS/_uniforms_box.sqf
@@ -38,18 +38,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\baf_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\baf_e_rifleman.sqf"],
-		["Echo AR", "loadouts\baf_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\baf_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\baf_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\baf_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\baf_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\baf_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\baf_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\baf_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\baf_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\baf_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\baf_e_rifleman.sqf"],
+		["Support AR", "loadouts\baf_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\baf_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\baf_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\baf_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\baf_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\baf_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\baf_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\baf_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\baf_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\baf_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -69,11 +69,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\baf_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\baf_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/loadouts/MODERN/T3_BW_Heer/T3_BW_Heer_D/_uniforms_box.sqf
+++ b/loadouts/MODERN/T3_BW_Heer/T3_BW_Heer_D/_uniforms_box.sqf
@@ -37,18 +37,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\bw_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\bw_e_rifleman.sqf"],
-		["Echo AR", "loadouts\bw_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\bw_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\bw_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\bw_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\bw_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\bw_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\bw_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\bw_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\bw_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\bw_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\bw_e_rifleman.sqf"],
+		["Support AR", "loadouts\bw_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\bw_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\bw_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\bw_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\bw_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\bw_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\bw_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\bw_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\bw_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\bw_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -68,11 +68,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\bw_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\bw_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/loadouts/MODERN/T3_BW_Heer/T3_BW_Heer_WD/_uniforms_box.sqf
+++ b/loadouts/MODERN/T3_BW_Heer/T3_BW_Heer_WD/_uniforms_box.sqf
@@ -37,18 +37,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\bw_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\bw_e_rifleman.sqf"],
-		["Echo AR", "loadouts\bw_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\bw_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\bw_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\bw_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\bw_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\bw_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\bw_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\bw_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\bw_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\bw_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\bw_e_rifleman.sqf"],
+		["Support AR", "loadouts\bw_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\bw_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\bw_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\bw_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\bw_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\bw_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\bw_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\bw_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\bw_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\bw_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -68,11 +68,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\bw_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\bw_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/loadouts/MODERN/T3_CAN_Army/T3_CAN_Army_D/_uniforms_box.sqf
+++ b/loadouts/MODERN/T3_CAN_Army/T3_CAN_Army_D/_uniforms_box.sqf
@@ -37,18 +37,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\can_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\can_e_rifleman.sqf"],
-		["Echo AR", "loadouts\can_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\can_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\can_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\can_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\can_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\can_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\can_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\can_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\can_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\can_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\can_e_rifleman.sqf"],
+		["Support AR", "loadouts\can_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\can_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\can_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\can_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\can_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\can_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\can_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\can_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\can_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\can_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -68,11 +68,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\can_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\can_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/loadouts/MODERN/T3_CAN_Army/T3_CAN_Army_WD/_uniforms_box.sqf
+++ b/loadouts/MODERN/T3_CAN_Army/T3_CAN_Army_WD/_uniforms_box.sqf
@@ -37,18 +37,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\can_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\can_e_rifleman.sqf"],
-		["Echo AR", "loadouts\can_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\can_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\can_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\can_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\can_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\can_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\can_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\can_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\can_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\can_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\can_e_rifleman.sqf"],
+		["Support AR", "loadouts\can_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\can_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\can_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\can_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\can_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\can_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\can_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\can_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\can_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\can_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -68,11 +68,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\can_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\can_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/loadouts/MODERN/T3_CDF_2020s/T3_CDF_2020s_D/_uniforms_box.sqf
+++ b/loadouts/MODERN/T3_CDF_2020s/T3_CDF_2020s_D/_uniforms_box.sqf
@@ -37,18 +37,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\cdf_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\cdf_e_rifleman.sqf"],
-		["Echo AR", "loadouts\cdf_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\cdf_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\cdf_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\cdf_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\cdf_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\cdf_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\cdf_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\cdf_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\cdf_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\cdf_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\cdf_e_rifleman.sqf"],
+		["Support AR", "loadouts\cdf_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\cdf_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\cdf_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\cdf_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\cdf_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\cdf_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\cdf_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\cdf_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\cdf_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\cdf_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -68,11 +68,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\cdf_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\cdf_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/loadouts/MODERN/T3_CDF_2020s/T3_CDF_2020s_W/_uniforms_box.sqf
+++ b/loadouts/MODERN/T3_CDF_2020s/T3_CDF_2020s_W/_uniforms_box.sqf
@@ -37,18 +37,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\cdf_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\cdf_e_rifleman.sqf"],
-		["Echo AR", "loadouts\cdf_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\cdf_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\cdf_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\cdf_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\cdf_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\cdf_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\cdf_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\cdf_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\cdf_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\cdf_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\cdf_e_rifleman.sqf"],
+		["Support AR", "loadouts\cdf_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\cdf_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\cdf_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\cdf_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\cdf_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\cdf_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\cdf_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\cdf_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\cdf_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\cdf_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -68,11 +68,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\cdf_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\cdf_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/loadouts/MODERN/T3_CDF_2020s/T3_CDF_2020s_WD/_uniforms_box.sqf
+++ b/loadouts/MODERN/T3_CDF_2020s/T3_CDF_2020s_WD/_uniforms_box.sqf
@@ -37,18 +37,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\cdf_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\cdf_e_rifleman.sqf"],
-		["Echo AR", "loadouts\cdf_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\cdf_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\cdf_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\cdf_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\cdf_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\cdf_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\cdf_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\cdf_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\cdf_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\cdf_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\cdf_e_rifleman.sqf"],
+		["Support AR", "loadouts\cdf_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\cdf_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\cdf_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\cdf_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\cdf_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\cdf_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\cdf_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\cdf_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\cdf_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\cdf_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -68,11 +68,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\cdf_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\cdf_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/loadouts/MODERN/T3_FIN_Army/T3_FIN_Army_W/_uniforms_box.sqf
+++ b/loadouts/MODERN/T3_FIN_Army/T3_FIN_Army_W/_uniforms_box.sqf
@@ -36,18 +36,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\fin_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\fin_e_rifleman.sqf"],
-		["Echo AR", "loadouts\fin_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\fin_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\fin_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\fin_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\fin_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\fin_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\fin_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\fin_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\fin_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\fin_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\fin_e_rifleman.sqf"],
+		["Support AR", "loadouts\fin_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\fin_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\fin_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\fin_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\fin_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\fin_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\fin_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\fin_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\fin_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\fin_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -67,11 +67,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\fin_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\fin_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/loadouts/MODERN/T3_FIN_Army/T3_FIN_Army_WD/_uniforms_box.sqf
+++ b/loadouts/MODERN/T3_FIN_Army/T3_FIN_Army_WD/_uniforms_box.sqf
@@ -36,18 +36,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\fin_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\fin_e_rifleman.sqf"],
-		["Echo AR", "loadouts\fin_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\fin_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\fin_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\fin_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\fin_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\fin_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\fin_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\fin_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\fin_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\fin_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\fin_e_rifleman.sqf"],
+		["Support AR", "loadouts\fin_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\fin_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\fin_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\fin_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\fin_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\fin_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\fin_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\fin_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\fin_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\fin_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -67,11 +67,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\fin_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\fin_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/loadouts/MODERN/T3_FRA_Land_Army/T3_FRA_Land_Army_D/_uniforms_box.sqf
+++ b/loadouts/MODERN/T3_FRA_Land_Army/T3_FRA_Land_Army_D/_uniforms_box.sqf
@@ -37,18 +37,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\fra_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\fra_e_rifleman.sqf"],
-		["Echo AR", "loadouts\fra_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\fra_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\fra_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\fra_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\fra_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\fra_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\fra_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\fra_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\fra_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\fra_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\fra_e_rifleman.sqf"],
+		["Support AR", "loadouts\fra_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\fra_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\fra_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\fra_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\fra_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\fra_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\fra_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\fra_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\fra_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\fra_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -68,11 +68,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\fra_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\fra_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/loadouts/MODERN/T3_FRA_Land_Army/T3_FRA_Land_Army_WD/_uniforms_box.sqf
+++ b/loadouts/MODERN/T3_FRA_Land_Army/T3_FRA_Land_Army_WD/_uniforms_box.sqf
@@ -37,18 +37,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\fra_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\fra_e_rifleman.sqf"],
-		["Echo AR", "loadouts\fra_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\fra_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\fra_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\fra_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\fra_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\fra_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\fra_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\fra_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\fra_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\fra_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\fra_e_rifleman.sqf"],
+		["Support AR", "loadouts\fra_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\fra_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\fra_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\fra_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\fra_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\fra_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\fra_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\fra_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\fra_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\fra_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -68,11 +68,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\fra_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\fra_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/loadouts/MODERN/T3_LDF_2020s/_uniforms_box.sqf
+++ b/loadouts/MODERN/T3_LDF_2020s/_uniforms_box.sqf
@@ -35,18 +35,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\ldf_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\ldf_e_rifleman.sqf"],
-		["Echo AR", "loadouts\ldf_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\ldf_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\ldf_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\ldf_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\ldf_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\ldf_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\ldf_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\ldf_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\ldf_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\ldf_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\ldf_e_rifleman.sqf"],
+		["Support AR", "loadouts\ldf_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\ldf_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\ldf_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\ldf_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\ldf_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\ldf_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\ldf_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\ldf_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\ldf_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\ldf_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -66,11 +66,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\ldf_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\ldf_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/loadouts/MODERN/T3_Militia/T3_Militia_D/_uniforms_box.sqf
+++ b/loadouts/MODERN/T3_Militia/T3_Militia_D/_uniforms_box.sqf
@@ -37,18 +37,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\mil_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\mil_e_rifleman.sqf"],
-		["Echo AR", "loadouts\mil_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\mil_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\mil_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\mil_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\mil_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\mil_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\mil_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\mil_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\mil_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\mil_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\mil_e_rifleman.sqf"],
+		["Support AR", "loadouts\mil_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\mil_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\mil_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\mil_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\mil_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\mil_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\mil_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\mil_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\mil_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\mil_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -66,11 +66,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\mil_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\mil_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/loadouts/MODERN/T3_Militia/T3_Militia_WD/_uniforms_box.sqf
+++ b/loadouts/MODERN/T3_Militia/T3_Militia_WD/_uniforms_box.sqf
@@ -37,18 +37,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\mil_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\mil_e_rifleman.sqf"],
-		["Echo AR", "loadouts\mil_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\mil_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\mil_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\mil_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\mil_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\mil_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\mil_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\mil_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\mil_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\mil_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\mil_e_rifleman.sqf"],
+		["Support AR", "loadouts\mil_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\mil_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\mil_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\mil_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\mil_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\mil_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\mil_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\mil_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\mil_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\mil_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -66,11 +66,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\mil_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\mil_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/loadouts/MODERN/T3_US_Army_2010s/_uniforms_box.sqf
+++ b/loadouts/MODERN/T3_US_Army_2010s/_uniforms_box.sqf
@@ -37,18 +37,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\us_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\us_e_rifleman.sqf"],
-		["Echo AR", "loadouts\us_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\us_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\us_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\us_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\us_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\us_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\us_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\us_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\us_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\us_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\us_e_rifleman.sqf"],
+		["Support AR", "loadouts\us_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\us_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\us_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\us_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\us_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\us_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\us_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\us_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\us_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\us_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -68,11 +68,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\us_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\us_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/loadouts/MODERN/T3_US_Army_2020s/T3_US_Army_OCP/_uniforms_box.sqf
+++ b/loadouts/MODERN/T3_US_Army_2020s/T3_US_Army_OCP/_uniforms_box.sqf
@@ -37,18 +37,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\us_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\us_e_rifleman.sqf"],
-		["Echo AR", "loadouts\us_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\us_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\us_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\us_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\us_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\us_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\us_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\us_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\us_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\us_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\us_e_rifleman.sqf"],
+		["Support AR", "loadouts\us_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\us_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\us_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\us_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\us_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\us_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\us_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\us_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\us_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\us_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -68,11 +68,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\us_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\us_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/loadouts/MODERN/T3_US_Army_2020s/T3_US_Army_OCP_Winter/_uniforms_box.sqf
+++ b/loadouts/MODERN/T3_US_Army_2020s/T3_US_Army_OCP_Winter/_uniforms_box.sqf
@@ -37,18 +37,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\us_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\us_e_rifleman.sqf"],
-		["Echo AR", "loadouts\us_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\us_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\us_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\us_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\us_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\us_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\us_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\us_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\us_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\us_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\us_e_rifleman.sqf"],
+		["Support AR", "loadouts\us_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\us_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\us_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\us_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\us_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\us_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\us_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\us_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\us_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\us_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -68,11 +68,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\us_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\us_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/loadouts/MODERN/T3_US_Marines_2010s/T3_US_Marines_D/_uniforms_box.sqf
+++ b/loadouts/MODERN/T3_US_Marines_2010s/T3_US_Marines_D/_uniforms_box.sqf
@@ -37,18 +37,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\us_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\us_e_rifleman.sqf"],
-		["Echo AR", "loadouts\us_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\us_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\us_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\us_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\us_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\us_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\us_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\us_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\us_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\us_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\us_e_rifleman.sqf"],
+		["Support AR", "loadouts\us_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\us_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\us_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\us_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\us_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\us_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\us_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\us_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\us_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\us_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -68,11 +68,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\us_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\us_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/loadouts/MODERN/T3_US_Marines_2010s/T3_US_Marines_W/_uniforms_box.sqf
+++ b/loadouts/MODERN/T3_US_Marines_2010s/T3_US_Marines_W/_uniforms_box.sqf
@@ -37,18 +37,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\us_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\us_e_rifleman.sqf"],
-		["Echo AR", "loadouts\us_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\us_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\us_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\us_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\us_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\us_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\us_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\us_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\us_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\us_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\us_e_rifleman.sqf"],
+		["Support AR", "loadouts\us_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\us_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\us_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\us_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\us_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\us_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\us_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\us_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\us_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\us_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -68,11 +68,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\us_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\us_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/loadouts/MODERN/T3_US_Marines_2010s/T3_US_Marines_WD/_uniforms_box.sqf
+++ b/loadouts/MODERN/T3_US_Marines_2010s/T3_US_Marines_WD/_uniforms_box.sqf
@@ -37,18 +37,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\us_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\us_e_rifleman.sqf"],
-		["Echo AR", "loadouts\us_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\us_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\us_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\us_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\us_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\us_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\us_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\us_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\us_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\us_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\us_e_rifleman.sqf"],
+		["Support AR", "loadouts\us_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\us_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\us_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\us_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\us_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\us_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\us_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\us_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\us_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\us_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -68,11 +68,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\us_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\us_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/loadouts/MODERN/T3_US_Marines_2020s/T3_US_Marines_D/_uniforms_box.sqf
+++ b/loadouts/MODERN/T3_US_Marines_2020s/T3_US_Marines_D/_uniforms_box.sqf
@@ -37,18 +37,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\us_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\us_e_rifleman.sqf"],
-		["Echo AR", "loadouts\us_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\us_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\us_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\us_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\us_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\us_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\us_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\us_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\us_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\us_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\us_e_rifleman.sqf"],
+		["Support AR", "loadouts\us_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\us_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\us_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\us_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\us_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\us_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\us_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\us_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\us_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\us_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -68,11 +68,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\us_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\us_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/loadouts/MODERN/T3_US_Marines_2020s/T3_US_Marines_W/_uniforms_box.sqf
+++ b/loadouts/MODERN/T3_US_Marines_2020s/T3_US_Marines_W/_uniforms_box.sqf
@@ -37,18 +37,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\us_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\us_e_rifleman.sqf"],
-		["Echo AR", "loadouts\us_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\us_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\us_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\us_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\us_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\us_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\us_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\us_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\us_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\us_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\us_e_rifleman.sqf"],
+		["Support AR", "loadouts\us_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\us_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\us_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\us_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\us_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\us_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\us_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\us_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\us_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\us_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -68,11 +68,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\us_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\us_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/loadouts/MODERN/T3_US_Marines_2020s/T3_US_Marines_WD/_uniforms_box.sqf
+++ b/loadouts/MODERN/T3_US_Marines_2020s/T3_US_Marines_WD/_uniforms_box.sqf
@@ -37,18 +37,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\us_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\us_e_rifleman.sqf"],
-		["Echo AR", "loadouts\us_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\us_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\us_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\us_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\us_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\us_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\us_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\us_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\us_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\us_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\us_e_rifleman.sqf"],
+		["Support AR", "loadouts\us_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\us_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\us_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\us_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\us_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\us_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\us_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\us_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\us_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\us_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -68,11 +68,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\us_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\us_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/loadouts/MODERN/T3_Western_PMC/_uniforms_box.sqf
+++ b/loadouts/MODERN/T3_Western_PMC/_uniforms_box.sqf
@@ -38,18 +38,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\pmc_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\pmc_e_rifleman.sqf"],
-		["Echo AR", "loadouts\pmc_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\pmc_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\pmc_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\pmc_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\pmc_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\pmc_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\pmc_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\pmc_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\pmc_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\pmc_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\pmc_e_rifleman.sqf"],
+		["Support AR", "loadouts\pmc_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\pmc_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\pmc_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\pmc_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\pmc_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\pmc_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\pmc_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\pmc_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\pmc_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\pmc_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -68,11 +68,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\pmc_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\pmc_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/loadouts/RETRO/T1_US_Delta_Force_2000s/T1_US_Delta_Force_2000s_D/_uniforms_box.sqf
+++ b/loadouts/RETRO/T1_US_Delta_Force_2000s/T1_US_Delta_Force_2000s_D/_uniforms_box.sqf
@@ -37,18 +37,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\us_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\us_e_rifleman.sqf"],
-		["Echo AR", "loadouts\us_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\us_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\us_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\us_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\us_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\us_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\us_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\us_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\us_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\us_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\us_e_rifleman.sqf"],
+		["Support AR", "loadouts\us_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\us_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\us_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\us_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\us_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\us_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\us_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\us_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\us_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\us_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -67,11 +67,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\us_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\us_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/loadouts/RETRO/T1_US_Delta_Force_2000s/T1_US_Delta_Force_2000s_UCP/_uniforms_box.sqf
+++ b/loadouts/RETRO/T1_US_Delta_Force_2000s/T1_US_Delta_Force_2000s_UCP/_uniforms_box.sqf
@@ -37,18 +37,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\us_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\us_e_rifleman.sqf"],
-		["Echo AR", "loadouts\us_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\us_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\us_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\us_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\us_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\us_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\us_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\us_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\us_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\us_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\us_e_rifleman.sqf"],
+		["Support AR", "loadouts\us_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\us_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\us_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\us_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\us_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\us_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\us_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\us_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\us_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\us_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -67,11 +67,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\us_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\us_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/loadouts/RETRO/T1_US_Delta_Force_2000s/T1_US_Delta_Force_2000s_WD/_uniforms_box.sqf
+++ b/loadouts/RETRO/T1_US_Delta_Force_2000s/T1_US_Delta_Force_2000s_WD/_uniforms_box.sqf
@@ -37,18 +37,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\us_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\us_e_rifleman.sqf"],
-		["Echo AR", "loadouts\us_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\us_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\us_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\us_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\us_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\us_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\us_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\us_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\us_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\us_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\us_e_rifleman.sqf"],
+		["Support AR", "loadouts\us_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\us_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\us_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\us_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\us_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\us_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\us_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\us_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\us_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\us_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -67,11 +67,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\us_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\us_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/loadouts/RETRO/T1_US_Delta_Force_80s_90s/T3_US_Delta_Force_80s_90s_D/_uniforms_box.sqf
+++ b/loadouts/RETRO/T1_US_Delta_Force_80s_90s/T3_US_Delta_Force_80s_90s_D/_uniforms_box.sqf
@@ -37,18 +37,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\us_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\us_e_rifleman.sqf"],
-		["Echo AR", "loadouts\us_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\us_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\us_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\us_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\us_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\us_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\us_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\us_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\us_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\us_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\us_e_rifleman.sqf"],
+		["Support AR", "loadouts\us_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\us_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\us_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\us_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\us_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\us_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\us_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\us_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\us_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\us_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -67,11 +67,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\us_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\us_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/loadouts/RETRO/T1_US_Delta_Force_80s_90s/T3_US_Delta_Force_80s_90s_WD/_uniforms_box.sqf
+++ b/loadouts/RETRO/T1_US_Delta_Force_80s_90s/T3_US_Delta_Force_80s_90s_WD/_uniforms_box.sqf
@@ -37,18 +37,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\us_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\us_e_rifleman.sqf"],
-		["Echo AR", "loadouts\us_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\us_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\us_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\us_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\us_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\us_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\us_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\us_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\us_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\us_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\us_e_rifleman.sqf"],
+		["Support AR", "loadouts\us_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\us_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\us_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\us_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\us_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\us_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\us_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\us_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\us_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\us_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -67,11 +67,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\us_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\us_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/loadouts/RETRO/T3_AUS_RAR_2000s/T3_AUS_RAR_2000s_D/_uniforms_box.sqf
+++ b/loadouts/RETRO/T3_AUS_RAR_2000s/T3_AUS_RAR_2000s_D/_uniforms_box.sqf
@@ -37,18 +37,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\aus_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\aus_e_rifleman.sqf"],
-		["Echo AR", "loadouts\aus_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\aus_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\aus_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\aus_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\aus_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\aus_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\aus_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\aus_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\aus_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\aus_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\aus_e_rifleman.sqf"],
+		["Support AR", "loadouts\aus_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\aus_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\aus_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\aus_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\aus_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\aus_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\aus_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\aus_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\aus_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\aus_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -68,11 +68,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\aus_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\aus_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/loadouts/RETRO/T3_AUS_RAR_2000s/T3_AUS_RAR_2000s_WD/_uniforms_box.sqf
+++ b/loadouts/RETRO/T3_AUS_RAR_2000s/T3_AUS_RAR_2000s_WD/_uniforms_box.sqf
@@ -37,18 +37,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\aus_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\aus_e_rifleman.sqf"],
-		["Echo AR", "loadouts\aus_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\aus_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\aus_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\aus_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\aus_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\aus_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\aus_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\aus_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\aus_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\aus_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\aus_e_rifleman.sqf"],
+		["Support AR", "loadouts\aus_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\aus_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\aus_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\aus_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\aus_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\aus_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\aus_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\aus_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\aus_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\aus_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -68,11 +68,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\aus_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\aus_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/loadouts/RETRO/T3_BAF_2000s/T3_BAF_2000s_DDPM/T3_BAF_2000s_DDPM_PARAS/_uniforms_box.sqf
+++ b/loadouts/RETRO/T3_BAF_2000s/T3_BAF_2000s_DDPM/T3_BAF_2000s_DDPM_PARAS/_uniforms_box.sqf
@@ -37,18 +37,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\baf_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\baf_e_rifleman.sqf"],
-		["Echo AR", "loadouts\baf_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\baf_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\baf_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\baf_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\baf_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\baf_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\baf_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\baf_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\baf_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\baf_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\baf_e_rifleman.sqf"],
+		["Support AR", "loadouts\baf_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\baf_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\baf_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\baf_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\baf_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\baf_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\baf_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\baf_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\baf_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\baf_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -67,11 +67,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\baf_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\baf_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/loadouts/RETRO/T3_BAF_2000s/T3_BAF_2000s_DDPM/T3_BAF_2000s_DDPM_RMC/_uniforms_box.sqf
+++ b/loadouts/RETRO/T3_BAF_2000s/T3_BAF_2000s_DDPM/T3_BAF_2000s_DDPM_RMC/_uniforms_box.sqf
@@ -37,18 +37,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\baf_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\baf_e_rifleman.sqf"],
-		["Echo AR", "loadouts\baf_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\baf_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\baf_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\baf_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\baf_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\baf_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\baf_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\baf_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\baf_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\baf_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\baf_e_rifleman.sqf"],
+		["Support AR", "loadouts\baf_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\baf_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\baf_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\baf_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\baf_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\baf_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\baf_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\baf_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\baf_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\baf_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -67,11 +67,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\baf_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\baf_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/loadouts/RETRO/T3_BAF_2000s/T3_BAF_2000s_DDPM/T3_BAF_2000s_DDPM_SCOTS/_uniforms_box.sqf
+++ b/loadouts/RETRO/T3_BAF_2000s/T3_BAF_2000s_DDPM/T3_BAF_2000s_DDPM_SCOTS/_uniforms_box.sqf
@@ -37,18 +37,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\baf_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\baf_e_rifleman.sqf"],
-		["Echo AR", "loadouts\baf_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\baf_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\baf_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\baf_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\baf_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\baf_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\baf_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\baf_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\baf_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\baf_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\baf_e_rifleman.sqf"],
+		["Support AR", "loadouts\baf_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\baf_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\baf_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\baf_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\baf_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\baf_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\baf_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\baf_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\baf_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\baf_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -67,11 +67,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\baf_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\baf_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/loadouts/RETRO/T3_BAF_2000s/T3_BAF_2000s_DPM/T3_BAF_2000s_DPM_PARAS/_uniforms_box.sqf
+++ b/loadouts/RETRO/T3_BAF_2000s/T3_BAF_2000s_DPM/T3_BAF_2000s_DPM_PARAS/_uniforms_box.sqf
@@ -37,18 +37,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\baf_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\baf_e_rifleman.sqf"],
-		["Echo AR", "loadouts\baf_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\baf_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\baf_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\baf_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\baf_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\baf_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\baf_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\baf_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\baf_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\baf_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\baf_e_rifleman.sqf"],
+		["Support AR", "loadouts\baf_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\baf_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\baf_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\baf_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\baf_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\baf_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\baf_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\baf_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\baf_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\baf_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -67,11 +67,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\baf_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\baf_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/loadouts/RETRO/T3_BAF_2000s/T3_BAF_2000s_DPM/T3_BAF_2000s_DPM_RMC/_uniforms_box.sqf
+++ b/loadouts/RETRO/T3_BAF_2000s/T3_BAF_2000s_DPM/T3_BAF_2000s_DPM_RMC/_uniforms_box.sqf
@@ -37,18 +37,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\baf_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\baf_e_rifleman.sqf"],
-		["Echo AR", "loadouts\baf_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\baf_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\baf_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\baf_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\baf_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\baf_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\baf_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\baf_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\baf_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\baf_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\baf_e_rifleman.sqf"],
+		["Support AR", "loadouts\baf_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\baf_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\baf_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\baf_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\baf_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\baf_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\baf_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\baf_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\baf_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\baf_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -67,11 +67,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\baf_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\baf_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/loadouts/RETRO/T3_BAF_2000s/T3_BAF_2000s_DPM/T3_BAF_2000s_DPM_SCOTS/_uniforms_box.sqf
+++ b/loadouts/RETRO/T3_BAF_2000s/T3_BAF_2000s_DPM/T3_BAF_2000s_DPM_SCOTS/_uniforms_box.sqf
@@ -37,18 +37,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\baf_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\baf_e_rifleman.sqf"],
-		["Echo AR", "loadouts\baf_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\baf_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\baf_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\baf_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\baf_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\baf_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\baf_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\baf_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\baf_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\baf_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\baf_e_rifleman.sqf"],
+		["Support AR", "loadouts\baf_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\baf_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\baf_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\baf_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\baf_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\baf_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\baf_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\baf_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\baf_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\baf_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -67,11 +67,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\baf_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\baf_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/loadouts/RETRO/T3_BAF_2000s/T3_BAF_2000s_DPM_Jungle/T3_BAF_2000s_DPM_Jungle_PARAS/_uniforms_box.sqf
+++ b/loadouts/RETRO/T3_BAF_2000s/T3_BAF_2000s_DPM_Jungle/T3_BAF_2000s_DPM_Jungle_PARAS/_uniforms_box.sqf
@@ -37,18 +37,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\baf_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\baf_e_rifleman.sqf"],
-		["Echo AR", "loadouts\baf_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\baf_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\baf_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\baf_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\baf_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\baf_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\baf_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\baf_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\baf_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\baf_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\baf_e_rifleman.sqf"],
+		["Support AR", "loadouts\baf_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\baf_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\baf_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\baf_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\baf_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\baf_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\baf_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\baf_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\baf_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\baf_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -67,11 +67,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\baf_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\baf_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/loadouts/RETRO/T3_BAF_2000s/T3_BAF_2000s_DPM_Jungle/T3_BAF_2000s_DPM_Jungle_RMC/_uniforms_box.sqf
+++ b/loadouts/RETRO/T3_BAF_2000s/T3_BAF_2000s_DPM_Jungle/T3_BAF_2000s_DPM_Jungle_RMC/_uniforms_box.sqf
@@ -37,18 +37,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\baf_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\baf_e_rifleman.sqf"],
-		["Echo AR", "loadouts\baf_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\baf_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\baf_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\baf_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\baf_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\baf_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\baf_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\baf_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\baf_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\baf_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\baf_e_rifleman.sqf"],
+		["Support AR", "loadouts\baf_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\baf_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\baf_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\baf_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\baf_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\baf_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\baf_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\baf_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\baf_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\baf_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -67,11 +67,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\baf_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\baf_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/loadouts/RETRO/T3_BAF_2000s/T3_BAF_2000s_DPM_Jungle/T3_BAF_2000s_DPM_Jungle_SCOTS/_uniforms_box.sqf
+++ b/loadouts/RETRO/T3_BAF_2000s/T3_BAF_2000s_DPM_Jungle/T3_BAF_2000s_DPM_Jungle_SCOTS/_uniforms_box.sqf
@@ -37,18 +37,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\baf_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\baf_e_rifleman.sqf"],
-		["Echo AR", "loadouts\baf_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\baf_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\baf_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\baf_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\baf_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\baf_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\baf_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\baf_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\baf_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\baf_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\baf_e_rifleman.sqf"],
+		["Support AR", "loadouts\baf_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\baf_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\baf_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\baf_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\baf_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\baf_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\baf_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\baf_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\baf_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\baf_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -67,11 +67,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\baf_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\baf_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/loadouts/RETRO/T3_BAF_2000s/T3_BAF_2000s_DPM_Temperate/T3_BAF_2000s_DPM_Temperate_PARAS/_uniforms_box.sqf
+++ b/loadouts/RETRO/T3_BAF_2000s/T3_BAF_2000s_DPM_Temperate/T3_BAF_2000s_DPM_Temperate_PARAS/_uniforms_box.sqf
@@ -37,18 +37,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\baf_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\baf_e_rifleman.sqf"],
-		["Echo AR", "loadouts\baf_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\baf_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\baf_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\baf_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\baf_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\baf_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\baf_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\baf_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\baf_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\baf_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\baf_e_rifleman.sqf"],
+		["Support AR", "loadouts\baf_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\baf_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\baf_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\baf_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\baf_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\baf_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\baf_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\baf_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\baf_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\baf_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -67,11 +67,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\baf_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\baf_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/loadouts/RETRO/T3_BAF_2000s/T3_BAF_2000s_DPM_Temperate/T3_BAF_2000s_DPM_Temperate_RMC/_uniforms_box.sqf
+++ b/loadouts/RETRO/T3_BAF_2000s/T3_BAF_2000s_DPM_Temperate/T3_BAF_2000s_DPM_Temperate_RMC/_uniforms_box.sqf
@@ -37,18 +37,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\baf_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\baf_e_rifleman.sqf"],
-		["Echo AR", "loadouts\baf_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\baf_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\baf_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\baf_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\baf_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\baf_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\baf_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\baf_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\baf_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\baf_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\baf_e_rifleman.sqf"],
+		["Support AR", "loadouts\baf_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\baf_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\baf_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\baf_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\baf_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\baf_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\baf_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\baf_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\baf_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\baf_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -67,11 +67,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\baf_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\baf_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/loadouts/RETRO/T3_BAF_2000s/T3_BAF_2000s_DPM_Temperate/T3_BAF_2000s_DPM_Temperate_SCOTS/_uniforms_box.sqf
+++ b/loadouts/RETRO/T3_BAF_2000s/T3_BAF_2000s_DPM_Temperate/T3_BAF_2000s_DPM_Temperate_SCOTS/_uniforms_box.sqf
@@ -37,18 +37,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\baf_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\baf_e_rifleman.sqf"],
-		["Echo AR", "loadouts\baf_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\baf_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\baf_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\baf_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\baf_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\baf_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\baf_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\baf_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\baf_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\baf_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\baf_e_rifleman.sqf"],
+		["Support AR", "loadouts\baf_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\baf_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\baf_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\baf_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\baf_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\baf_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\baf_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\baf_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\baf_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\baf_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -67,11 +67,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\baf_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\baf_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/loadouts/RETRO/T3_BAF_70s_80s/T3_BAF_70s_80s_PARAS/_uniforms_box.sqf
+++ b/loadouts/RETRO/T3_BAF_70s_80s/T3_BAF_70s_80s_PARAS/_uniforms_box.sqf
@@ -37,18 +37,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\baf_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\baf_e_rifleman.sqf"],
-		["Echo AR", "loadouts\baf_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\baf_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\baf_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\baf_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\baf_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\baf_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\baf_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\baf_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\baf_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\baf_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\baf_e_rifleman.sqf"],
+		["Support AR", "loadouts\baf_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\baf_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\baf_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\baf_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\baf_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\baf_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\baf_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\baf_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\baf_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\baf_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -66,11 +66,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\baf_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\baf_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/loadouts/RETRO/T3_BAF_70s_80s/T3_BAF_70s_80s_RIFLES/_uniforms_box.sqf
+++ b/loadouts/RETRO/T3_BAF_70s_80s/T3_BAF_70s_80s_RIFLES/_uniforms_box.sqf
@@ -37,18 +37,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\baf_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\baf_e_rifleman.sqf"],
-		["Echo AR", "loadouts\baf_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\baf_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\baf_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\baf_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\baf_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\baf_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\baf_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\baf_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\baf_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\baf_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\baf_e_rifleman.sqf"],
+		["Support AR", "loadouts\baf_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\baf_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\baf_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\baf_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\baf_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\baf_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\baf_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\baf_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\baf_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\baf_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -66,11 +66,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\baf_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\baf_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/loadouts/RETRO/T3_BAF_70s_80s/T3_BAF_70s_80s_RMC/_uniforms_box.sqf
+++ b/loadouts/RETRO/T3_BAF_70s_80s/T3_BAF_70s_80s_RMC/_uniforms_box.sqf
@@ -37,18 +37,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\baf_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\baf_e_rifleman.sqf"],
-		["Echo AR", "loadouts\baf_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\baf_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\baf_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\baf_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\baf_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\baf_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\baf_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\baf_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\baf_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\baf_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\baf_e_rifleman.sqf"],
+		["Support AR", "loadouts\baf_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\baf_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\baf_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\baf_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\baf_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\baf_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\baf_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\baf_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\baf_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\baf_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -66,11 +66,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\baf_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\baf_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/loadouts/RETRO/T3_BAF_70s_80s/T3_BAF_70s_80s_SCOTS/_uniforms_box.sqf
+++ b/loadouts/RETRO/T3_BAF_70s_80s/T3_BAF_70s_80s_SCOTS/_uniforms_box.sqf
@@ -37,18 +37,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\baf_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\baf_e_rifleman.sqf"],
-		["Echo AR", "loadouts\baf_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\baf_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\baf_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\baf_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\baf_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\baf_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\baf_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\baf_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\baf_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\baf_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\baf_e_rifleman.sqf"],
+		["Support AR", "loadouts\baf_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\baf_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\baf_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\baf_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\baf_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\baf_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\baf_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\baf_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\baf_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\baf_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -66,11 +66,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\baf_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\baf_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/loadouts/RETRO/T3_CDF_90s_2000s/_uniforms_box.sqf
+++ b/loadouts/RETRO/T3_CDF_90s_2000s/_uniforms_box.sqf
@@ -37,18 +37,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\cdf_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\cdf_e_rifleman.sqf"],
-		["Echo AR", "loadouts\cdf_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\cdf_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\cdf_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\cdf_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\cdf_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\cdf_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\cdf_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\cdf_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\cdf_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\cdf_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\cdf_e_rifleman.sqf"],
+		["Support AR", "loadouts\cdf_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\cdf_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\cdf_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\cdf_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\cdf_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\cdf_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\cdf_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\cdf_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\cdf_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\cdf_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -66,11 +66,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\cdf_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\cdf_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/loadouts/RETRO/T3_LPDF_80s_90s/_uniforms_box.sqf
+++ b/loadouts/RETRO/T3_LPDF_80s_90s/_uniforms_box.sqf
@@ -37,18 +37,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\lpdf_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\lpdf_e_rifleman.sqf"],
-		["Echo AR", "loadouts\lpdf_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\lpdf_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\lpdf_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\lpdf_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\lpdf_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\lpdf_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\lpdf_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\lpdf_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\lpdf_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\lpdf_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\lpdf_e_rifleman.sqf"],
+		["Support AR", "loadouts\lpdf_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\lpdf_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\lpdf_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\lpdf_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\lpdf_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\lpdf_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\lpdf_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\lpdf_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\lpdf_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\lpdf_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -66,11 +66,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\lpdf_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\lpdf_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/loadouts/RETRO/T3_US_Army_2000s/T3_US_Army_2000s_D/_uniforms_box.sqf
+++ b/loadouts/RETRO/T3_US_Army_2000s/T3_US_Army_2000s_D/_uniforms_box.sqf
@@ -37,18 +37,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\us_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\us_e_rifleman.sqf"],
-		["Echo AR", "loadouts\us_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\us_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\us_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\us_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\us_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\us_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\us_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\us_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\us_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\us_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\us_e_rifleman.sqf"],
+		["Support AR", "loadouts\us_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\us_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\us_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\us_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\us_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\us_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\us_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\us_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\us_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\us_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -67,11 +67,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\us_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\us_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/loadouts/RETRO/T3_US_Army_2000s/T3_US_Army_2000s_UCP/_uniforms_box.sqf
+++ b/loadouts/RETRO/T3_US_Army_2000s/T3_US_Army_2000s_UCP/_uniforms_box.sqf
@@ -37,18 +37,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\us_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\us_e_rifleman.sqf"],
-		["Echo AR", "loadouts\us_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\us_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\us_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\us_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\us_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\us_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\us_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\us_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\us_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\us_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\us_e_rifleman.sqf"],
+		["Support AR", "loadouts\us_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\us_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\us_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\us_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\us_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\us_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\us_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\us_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\us_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\us_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -67,11 +67,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\us_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\us_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/loadouts/RETRO/T3_US_Army_2000s/T3_US_Army_2000s_WD/_uniforms_box.sqf
+++ b/loadouts/RETRO/T3_US_Army_2000s/T3_US_Army_2000s_WD/_uniforms_box.sqf
@@ -37,18 +37,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\us_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\us_e_rifleman.sqf"],
-		["Echo AR", "loadouts\us_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\us_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\us_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\us_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\us_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\us_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\us_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\us_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\us_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\us_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\us_e_rifleman.sqf"],
+		["Support AR", "loadouts\us_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\us_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\us_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\us_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\us_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\us_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\us_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\us_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\us_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\us_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -67,11 +67,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\us_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\us_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/loadouts/RETRO/T3_US_Army_80s_90s/T3_US_Army_80s_90s_D/_uniforms_box.sqf
+++ b/loadouts/RETRO/T3_US_Army_80s_90s/T3_US_Army_80s_90s_D/_uniforms_box.sqf
@@ -37,18 +37,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\us_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\us_e_rifleman.sqf"],
-		["Echo AR", "loadouts\us_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\us_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\us_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\us_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\us_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\us_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\us_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\us_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\us_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\us_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\us_e_rifleman.sqf"],
+		["Support AR", "loadouts\us_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\us_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\us_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\us_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\us_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\us_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\us_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\us_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\us_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\us_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -67,11 +67,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\us_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\us_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/loadouts/RETRO/T3_US_Army_80s_90s/T3_US_Army_80s_90s_WD/_uniforms_box.sqf
+++ b/loadouts/RETRO/T3_US_Army_80s_90s/T3_US_Army_80s_90s_WD/_uniforms_box.sqf
@@ -37,18 +37,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\us_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\us_e_rifleman.sqf"],
-		["Echo AR", "loadouts\us_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\us_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\us_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\us_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\us_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\us_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\us_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\us_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\us_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\us_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\us_e_rifleman.sqf"],
+		["Support AR", "loadouts\us_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\us_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\us_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\us_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\us_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\us_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\us_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\us_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\us_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\us_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -67,11 +67,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\us_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\us_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/loadouts/RETRO/T3_US_Marines_2000s/T3_USMC_2000s_D/_uniforms_box.sqf
+++ b/loadouts/RETRO/T3_US_Marines_2000s/T3_USMC_2000s_D/_uniforms_box.sqf
@@ -37,18 +37,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\us_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\us_e_rifleman.sqf"],
-		["Echo AR", "loadouts\us_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\us_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\us_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\us_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\us_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\us_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\us_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\us_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\us_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\us_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\us_e_rifleman.sqf"],
+		["Support AR", "loadouts\us_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\us_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\us_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\us_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\us_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\us_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\us_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\us_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\us_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\us_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -67,11 +67,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\us_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\us_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/loadouts/RETRO/T3_US_Marines_2000s/T3_USMC_2000s_WD/_uniforms_box.sqf
+++ b/loadouts/RETRO/T3_US_Marines_2000s/T3_USMC_2000s_WD/_uniforms_box.sqf
@@ -37,18 +37,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\us_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\us_e_rifleman.sqf"],
-		["Echo AR", "loadouts\us_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\us_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\us_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\us_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\us_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\us_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\us_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\us_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\us_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\us_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\us_e_rifleman.sqf"],
+		["Support AR", "loadouts\us_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\us_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\us_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\us_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\us_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\us_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\us_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\us_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\us_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\us_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -67,11 +67,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\us_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\us_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/loadouts/RETRO/T3_US_Marines_80s_90s/T3_US_Marines_80s_90s_D/_uniforms_box.sqf
+++ b/loadouts/RETRO/T3_US_Marines_80s_90s/T3_US_Marines_80s_90s_D/_uniforms_box.sqf
@@ -37,18 +37,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\us_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\us_e_rifleman.sqf"],
-		["Echo AR", "loadouts\us_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\us_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\us_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\us_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\us_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\us_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\us_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\us_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\us_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\us_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\us_e_rifleman.sqf"],
+		["Support AR", "loadouts\us_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\us_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\us_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\us_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\us_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\us_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\us_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\us_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\us_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\us_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -67,11 +67,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\us_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\us_e_rifleman.sqf"]
 	]]
 ];
 					

--- a/loadouts/RETRO/T3_US_Marines_80s_90s/T3_US_Marines_80s_90s_WD/_uniforms_box.sqf
+++ b/loadouts/RETRO/T3_US_Marines_80s_90s/T3_US_Marines_80s_90s_WD/_uniforms_box.sqf
@@ -37,18 +37,18 @@ _uniforms = [
 		["Operator Engineer (Repair)", "loadouts\us_o_e_repair.sqf"]
 	]],
 
-	["Echo", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
-		[["Echo Rifleman", "loadouts\us_e_rifleman.sqf"],
-		["Echo AR", "loadouts\us_e_ar.sqf"],
-		["Echo Engineer (Demo)", "loadouts\us_e_e_demo.sqf"],
-		["Echo Engineer (EOD)", "loadouts\us_e_e_eod.sqf"],
-		["Echo Engineer (Fortification)", "loadouts\us_e_e_fort.sqf"],
-		["Echo Engineer (Repair)", "loadouts\us_e_e_repair.sqf"],
-		["Echo Heavy Weapons (Mortar)", "loadouts\us_e_mor.sqf"],
-		["Echo Asst. Heavy Weapons (Mortar)", "loadouts\us_e_morAsst.sqf"],
-		["Echo Heavy Weapons (HAT)", "loadouts\us_e_hat.sqf"],
-		["Echo Asst. Heavy Weapons (HAT)", "loadouts\us_e_hatAsst.sqf"],
-		["Echo Driver", "loadouts\us_e_driver.sqf"]
+	["Support", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_maint.paa",
+		[["Support Rifleman", "loadouts\us_e_rifleman.sqf"],
+		["Support AR", "loadouts\us_e_ar.sqf"],
+		["Support Engineer (Demo)", "loadouts\us_e_e_demo.sqf"],
+		["Support Engineer (EOD)", "loadouts\us_e_e_eod.sqf"],
+		["Support Engineer (Fortification)", "loadouts\us_e_e_fort.sqf"],
+		["Support Engineer (Repair)", "loadouts\us_e_e_repair.sqf"],
+		["Support Heavy Weapons (Mortar)", "loadouts\us_e_mor.sqf"],
+		["Support Asst. Heavy Weapons (Mortar)", "loadouts\us_e_morAsst.sqf"],
+		["Support Heavy Weapons (HAT)", "loadouts\us_e_hat.sqf"],
+		["Support Asst. Heavy Weapons (HAT)", "loadouts\us_e_hatAsst.sqf"],
+		["Support Driver", "loadouts\us_e_driver.sqf"]
 	]],
 
 	["Foxtrot", "#ff0000", "a3\ui_f\data\Map\Markers\NATO\b_armor.paa",
@@ -67,11 +67,6 @@ _uniforms = [
 		[["Rodeo Pilot", "loadouts\pilot_rotaryPilot.sqf"],
 		["Rodeo Co-Pilot (Crewman)", "loadouts\pilot_rotaryCrew.sqf"],
 		["Whiskey Pilot", "loadouts\pilot_fixedWing.sqf"]
-	]],
-
-	["Lima", "#ff8c00", "a3\ui_f\data\Map\Markers\NATO\b_support.paa",
-		[["Lima Technician", "loadouts\us_e_e_repair.sqf"],
-		["Lima Operator", "loadouts\us_e_rifleman.sqf"]
 	]]
 ];
 					


### PR DESCRIPTION
- Combined the Echo and Lima Loadouts in all uniforms boxes since the Loadouts were previously identical anyways, renamed from Echo to Support in uniform selection