### PR TITLE
Loadout Updates Feb 26

### DIFF
--- a/loadouts/MODERN/T1_BAF_SF/T1_BAF_SAS/aWeaponCall.sqf
+++ b/loadouts/MODERN/T1_BAF_SF/T1_BAF_SAS/aWeaponCall.sqf
@@ -77,7 +77,7 @@
     //5 - AutoRifle
     if (_Rifle == 5) then{
         _primaryArray = [
-            "7r_weap_l110a3"
+            "7r_weap_l110"
         ];
         _primaryAmmo = "rhsusf_200Rnd_556x45_mixed_soft_pouch_coyote";
     };

--- a/loadouts/MODERN/T1_BAF_SF/T1_BAF_SAS/aWeaponCall.sqf
+++ b/loadouts/MODERN/T1_BAF_SF/T1_BAF_SAS/aWeaponCall.sqf
@@ -77,7 +77,7 @@
     //5 - AutoRifle
     if (_Rifle == 5) then{
         _primaryArray = [
-            "rhs_weap_minimi_para_railed"
+            "7r_weap_l110a3"
         ];
         _primaryAmmo = "rhsusf_200Rnd_556x45_mixed_soft_pouch_coyote";
     };

--- a/loadouts/MODERN/T1_BAF_SF/T1_BAF_SBS/aWeaponCall.sqf
+++ b/loadouts/MODERN/T1_BAF_SF/T1_BAF_SBS/aWeaponCall.sqf
@@ -77,7 +77,7 @@
     //5 - AutoRifle
     if (_Rifle == 5) then{
         _primaryArray = [
-            "7r_weap_l110a3"
+            "7r_weap_l110"
         ];
         _primaryAmmo = "rhsusf_200Rnd_556x45_mixed_soft_pouch_coyote";
     };

--- a/loadouts/MODERN/T1_BAF_SF/T1_BAF_SBS/aWeaponCall.sqf
+++ b/loadouts/MODERN/T1_BAF_SF/T1_BAF_SBS/aWeaponCall.sqf
@@ -77,7 +77,7 @@
     //5 - AutoRifle
     if (_Rifle == 5) then{
         _primaryArray = [
-            "rhs_weap_minimi_para_railed"
+            "7r_weap_l110a3"
         ];
         _primaryAmmo = "rhsusf_200Rnd_556x45_mixed_soft_pouch_coyote";
     };

--- a/loadouts/MODERN/T2_BAF_RMC(SOC)/aWeaponCall.sqf
+++ b/loadouts/MODERN/T2_BAF_RMC(SOC)/aWeaponCall.sqf
@@ -77,7 +77,7 @@
     //5 - AutoRifle
     if (_Rifle == 5) then{
         _primaryArray = [
-            "7r_weap_l110a3"
+            "7r_weap_l110"
         ];
         _primaryAmmo = "rhsusf_200Rnd_556x45_mixed_soft_pouch_coyote";
     };

--- a/loadouts/MODERN/T2_BAF_RMC(SOC)/aWeaponCall.sqf
+++ b/loadouts/MODERN/T2_BAF_RMC(SOC)/aWeaponCall.sqf
@@ -77,7 +77,7 @@
     //5 - AutoRifle
     if (_Rifle == 5) then{
         _primaryArray = [
-            "rhs_weap_minimi_para_railed"
+            "7r_weap_l110a3"
         ];
         _primaryAmmo = "rhsusf_200Rnd_556x45_mixed_soft_pouch_coyote";
     };

--- a/loadouts/MODERN/T2_CDF_Airborne/aWeaponCall.sqf
+++ b/loadouts/MODERN/T2_CDF_Airborne/aWeaponCall.sqf
@@ -71,7 +71,7 @@
     //5 - AutoRifle
     if (_Rifle == 5) then{
         _primaryArray = [
-            "rhs_weap_rpk74m_npz"
+            "rhs_weap_rpk74m"
         ];
         _primaryAmmo = "rhs_60Rnd_545X39_7N10_AK_mixed";
     };

--- a/loadouts/MODERN/T2_CDF_Airborne/cdf_e_ar.sqf
+++ b/loadouts/MODERN/T2_CDF_Airborne/cdf_e_ar.sqf
@@ -40,6 +40,7 @@ comment "Add Drip";
 comment "Add Weapons/Attachments";
     //1 - Rifle 1 | 2 - Rifle 2 | 3 - Grenadier | 4 - BattleRifle | 5 - AutoRifle | 6 - MMG | 7 - SPC | 8 - DMR
     [_unit, 5] call compile preprocessFileLineNumbers "loadouts\aWeaponCall.sqf";
+    [objNull, _unit] call compile preprocessFileLineNumbers "loadouts\optic_switch.sqf";
     _unit addPrimaryWeaponItem "rhsusf_acc_ELCAN";
 
 comment "Add Secondary/Attachments";

--- a/loadouts/MODERN/T2_CDF_Airborne/cdf_p_ar.sqf
+++ b/loadouts/MODERN/T2_CDF_Airborne/cdf_p_ar.sqf
@@ -40,6 +40,7 @@ comment "Add Drip";
 comment "Add Primary/Attachments";
     // 1 - Rifle 1 | 2 - Rifle 2 | 3 - Grenadier | 4 - BattleRifle | 5 - AutoRifle | 6 - MMG
     [_unit, 5] call compile preprocessFileLineNumbers "loadouts\aWeaponCall.sqf";
+    [objNull, _unit] call compile preprocessFileLineNumbers "loadouts\optic_switch.sqf";
     _unit addPrimaryWeaponItem "rhsusf_acc_ELCAN";
 
 comment "Add Secondary/Attachments";

--- a/loadouts/MODERN/T3_BAF_2020s/T3_BAF_Arctic/aWeaponCall.sqf
+++ b/loadouts/MODERN/T3_BAF_2020s/T3_BAF_Arctic/aWeaponCall.sqf
@@ -89,7 +89,7 @@
     //5 - AutoRifle
     if (_Rifle == 5) then{
         _primaryArray = [
-            "7r_weap_l110a3"
+            "7r_weap_l110"
         ];
         _primaryAmmo = "rhsusf_200Rnd_556x45_mixed_soft_pouch_coyote";
     };

--- a/loadouts/MODERN/T3_BAF_2020s/T3_BAF_Arctic/aWeaponCall.sqf
+++ b/loadouts/MODERN/T3_BAF_2020s/T3_BAF_Arctic/aWeaponCall.sqf
@@ -89,7 +89,7 @@
     //5 - AutoRifle
     if (_Rifle == 5) then{
         _primaryArray = [
-            "rhs_weap_minimi_para_railed"
+            "7r_weap_l110a3"
         ];
         _primaryAmmo = "rhsusf_200Rnd_556x45_mixed_soft_pouch_coyote";
     };

--- a/loadouts/MODERN/T3_BAF_2020s/T3_BAF_PARAS/aWeaponCall.sqf
+++ b/loadouts/MODERN/T3_BAF_2020s/T3_BAF_PARAS/aWeaponCall.sqf
@@ -89,7 +89,7 @@
     //5 - AutoRifle
     if (_Rifle == 5) then{
         _primaryArray = [
-            "7r_weap_l110a3"
+            "7r_weap_l110"
         ];
         _primaryAmmo = "rhsusf_200Rnd_556x45_mixed_soft_pouch_coyote";
     };

--- a/loadouts/MODERN/T3_BAF_2020s/T3_BAF_PARAS/aWeaponCall.sqf
+++ b/loadouts/MODERN/T3_BAF_2020s/T3_BAF_PARAS/aWeaponCall.sqf
@@ -89,7 +89,7 @@
     //5 - AutoRifle
     if (_Rifle == 5) then{
         _primaryArray = [
-            "rhs_weap_minimi_para_railed"
+            "7r_weap_l110a3"
         ];
         _primaryAmmo = "rhsusf_200Rnd_556x45_mixed_soft_pouch_coyote";
     };

--- a/loadouts/MODERN/T3_BAF_2020s/T3_BAF_RIFLES/aWeaponCall.sqf
+++ b/loadouts/MODERN/T3_BAF_2020s/T3_BAF_RIFLES/aWeaponCall.sqf
@@ -89,7 +89,7 @@
     //5 - AutoRifle
     if (_Rifle == 5) then{
         _primaryArray = [
-            "7r_weap_l110a3"
+            "7r_weap_l110"
         ];
         _primaryAmmo = "rhsusf_200Rnd_556x45_mixed_soft_pouch_coyote";
     };

--- a/loadouts/MODERN/T3_BAF_2020s/T3_BAF_RIFLES/aWeaponCall.sqf
+++ b/loadouts/MODERN/T3_BAF_2020s/T3_BAF_RIFLES/aWeaponCall.sqf
@@ -89,7 +89,7 @@
     //5 - AutoRifle
     if (_Rifle == 5) then{
         _primaryArray = [
-            "rhs_weap_minimi_para_railed"
+            "7r_weap_l110a3"
         ];
         _primaryAmmo = "rhsusf_200Rnd_556x45_mixed_soft_pouch_coyote";
     };

--- a/loadouts/MODERN/T3_BAF_2020s/T3_BAF_RMC/aWeaponCall.sqf
+++ b/loadouts/MODERN/T3_BAF_2020s/T3_BAF_RMC/aWeaponCall.sqf
@@ -89,7 +89,7 @@
     //5 - AutoRifle
     if (_Rifle == 5) then{
         _primaryArray = [
-            "7r_weap_l110a3"
+            "7r_weap_l110"
         ];
         _primaryAmmo = "rhsusf_200Rnd_556x45_mixed_soft_pouch_coyote";
     };

--- a/loadouts/MODERN/T3_BAF_2020s/T3_BAF_RMC/aWeaponCall.sqf
+++ b/loadouts/MODERN/T3_BAF_2020s/T3_BAF_RMC/aWeaponCall.sqf
@@ -89,7 +89,7 @@
     //5 - AutoRifle
     if (_Rifle == 5) then{
         _primaryArray = [
-            "rhs_weap_minimi_para_railed"
+            "7r_weap_l110a3"
         ];
         _primaryAmmo = "rhsusf_200Rnd_556x45_mixed_soft_pouch_coyote";
     };

--- a/loadouts/MODERN/T3_BAF_2020s/T3_BAF_SCOTS/aWeaponCall.sqf
+++ b/loadouts/MODERN/T3_BAF_2020s/T3_BAF_SCOTS/aWeaponCall.sqf
@@ -89,7 +89,7 @@
     //5 - AutoRifle
     if (_Rifle == 5) then{
         _primaryArray = [
-            "7r_weap_l110a3"
+            "7r_weap_l110"
         ];
         _primaryAmmo = "rhsusf_200Rnd_556x45_mixed_soft_pouch_coyote";
     };

--- a/loadouts/MODERN/T3_BAF_2020s/T3_BAF_SCOTS/aWeaponCall.sqf
+++ b/loadouts/MODERN/T3_BAF_2020s/T3_BAF_SCOTS/aWeaponCall.sqf
@@ -89,7 +89,7 @@
     //5 - AutoRifle
     if (_Rifle == 5) then{
         _primaryArray = [
-            "rhs_weap_minimi_para_railed"
+            "7r_weap_l110a3"
         ];
         _primaryAmmo = "rhsusf_200Rnd_556x45_mixed_soft_pouch_coyote";
     };

--- a/loadouts/MODERN/T3_CAN_Army/T3_CAN_Army_D/_big_box.sqf
+++ b/loadouts/MODERN/T3_CAN_Army/T3_CAN_Army_D/_big_box.sqf
@@ -4,7 +4,7 @@ if(isServer) then {
 	clearitemcargoGlobal this;
 	clearBackpackCargoGlobal this;
 	this addmagazinecargoGlobal ["tsp_popperCharge_auto_mag", 10];
-	this addmagazinecargoGlobal ["rhsusf_200Rnd_556x45_mixed_soft_pouch_coyote", 60];
+	this addmagazinecargoGlobal ["rhsusf_200rnd_556x45_mixed_box_black", 60];
 	this addmagazinecargoGlobal ["rhsusf_100Rnd_762x51_m80a1epr", 40];
     this addmagazinecargoGlobal ["UK3CB_P320_9x19_17Rnd", 60];
     this addweaponcargoGlobal ["rhs_weap_m72a7", 20];

--- a/loadouts/MODERN/T3_CAN_Army/T3_CAN_Army_D/_supply_drop_content.sqf
+++ b/loadouts/MODERN/T3_CAN_Army/T3_CAN_Army_D/_supply_drop_content.sqf
@@ -21,7 +21,7 @@ if (_type == 1) then {
 	_box addmagazinecargoGlobal ["tsp_frameCharge_mag", 1];
 	_box addmagazinecargoGlobal ["rhs_mag_30Rnd_556x45_M855A1_Stanag_Pull", 72];
 	_box addmagazinecargoGlobal ["UK3CB_P320_9x19_17Rnd", 24];
-	_box addmagazinecargoGlobal ["rhsusf_200Rnd_556x45_mixed_soft_pouch_coyote", 12];
+	_box addmagazinecargoGlobal ["rhsusf_200rnd_556x45_mixed_box_black", 12];
     _box addmagazinecargoGlobal ["rhsusf_100Rnd_762x51_m80a1epr", 8];
 	_box addmagazinecargoGlobal ["UK3CB_BAF_12G_Pellets", 16];
 	_box addmagazinecargoGlobal ["UK3CB_BAF_12G_Slugs", 16];
@@ -80,7 +80,7 @@ if (_type == 4) then {
 	_box addmagazinecargoGlobal ["tsp_stickCharge_auto_mag", 2];
 	_box addmagazinecargoGlobal ["tsp_frameCharge_mag", 1];
 	_box addmagazinecargoGlobal ["rhs_mag_30Rnd_556x45_M855A1_Stanag_Pull", 36];
-	_box addmagazinecargoGlobal ["rhsusf_200Rnd_556x45_mixed_soft_pouch_coyote", 6];
+	_box addmagazinecargoGlobal ["rhsusf_200rnd_556x45_mixed_box_black", 6];
     _box addmagazinecargoGlobal ["20Rnd_762x51_Mag", 8];
 	_box addmagazinecargoGlobal ["UK3CB_P320_9x19_17Rnd", 8];
 	_box addWeaponCargoGlobal ["rhs_weap_m72a7", 2];

--- a/loadouts/MODERN/T3_CAN_Army/T3_CAN_Army_D/aWeaponCall.sqf
+++ b/loadouts/MODERN/T3_CAN_Army/T3_CAN_Army_D/aWeaponCall.sqf
@@ -72,9 +72,9 @@
     //5 - AutoRifle
     if (_Rifle == 5) then{
         _primaryArray = [
-            "rhs_weap_minimi_para_railed"
+            "7r_weap_c9"
         ];
-        _primaryAmmo = "rhsusf_200Rnd_556x45_mixed_soft_pouch_coyote";
+        _primaryAmmo = "rhsusf_200rnd_556x45_mixed_box_black";
     };
 
     //6 - MMG

--- a/loadouts/MODERN/T3_CAN_Army/T3_CAN_Army_D/can_e_ar.sqf
+++ b/loadouts/MODERN/T3_CAN_Army/T3_CAN_Army_D/can_e_ar.sqf
@@ -40,7 +40,7 @@ comment "Add Drip";
 comment "Add Weapons/Attachments";
     //1 - Rifle 1 | 2 - Rifle 2 | 3 - Grenadier | 4 - BattleRifle | 5 - AutoRifle | 6 - MMG | 7 - SPC | 8 - DMR
     [_unit, 5] call compile preprocessFileLineNumbers "loadouts\aWeaponCall.sqf";
-    _unit addPrimaryWeaponItem "7r_acc_c79_blk";
+    _unit addPrimaryWeaponItem "7r_acc_c79";
 
 comment "Add Secondary/Attachments";
 

--- a/loadouts/MODERN/T3_CAN_Army/T3_CAN_Army_D/can_p_ar.sqf
+++ b/loadouts/MODERN/T3_CAN_Army/T3_CAN_Army_D/can_p_ar.sqf
@@ -40,7 +40,7 @@ comment "Add Drip";
 comment "Add Primary/Attachments";
     // 1 - Rifle 1 | 2 - Rifle 2 | 3 - Grenadier | 4 - BattleRifle | 5 - AutoRifle | 6 - MMG
     [_unit, 5] call compile preprocessFileLineNumbers "loadouts\aWeaponCall.sqf";
-    _unit addPrimaryWeaponItem "7r_acc_c79_blk";
+    _unit addPrimaryWeaponItem "7r_acc_c79";
 
 comment "Add Secondary/Attachments";
 

--- a/loadouts/MODERN/T3_CAN_Army/T3_CAN_Army_WD/_big_box.sqf
+++ b/loadouts/MODERN/T3_CAN_Army/T3_CAN_Army_WD/_big_box.sqf
@@ -4,7 +4,7 @@ if(isServer) then {
 	clearitemcargoGlobal this;
 	clearBackpackCargoGlobal this;
 	this addmagazinecargoGlobal ["tsp_popperCharge_auto_mag", 10];
-	this addmagazinecargoGlobal ["rhsusf_200Rnd_556x45_mixed_soft_pouch_coyote", 60];
+	this addmagazinecargoGlobal ["rhsusf_200rnd_556x45_mixed_box_black", 60];
 	this addmagazinecargoGlobal ["rhsusf_100Rnd_762x51_m80a1epr", 40];
     this addmagazinecargoGlobal ["UK3CB_P320_9x19_17Rnd", 60];
     this addweaponcargoGlobal ["rhs_weap_m72a7", 20];

--- a/loadouts/MODERN/T3_CAN_Army/T3_CAN_Army_WD/_supply_drop_content.sqf
+++ b/loadouts/MODERN/T3_CAN_Army/T3_CAN_Army_WD/_supply_drop_content.sqf
@@ -21,7 +21,7 @@ if (_type == 1) then {
 	_box addmagazinecargoGlobal ["tsp_frameCharge_mag", 1];
 	_box addmagazinecargoGlobal ["rhs_mag_30Rnd_556x45_M855A1_Stanag_Pull", 72];
 	_box addmagazinecargoGlobal ["UK3CB_P320_9x19_17Rnd", 24];
-	_box addmagazinecargoGlobal ["rhsusf_200Rnd_556x45_mixed_soft_pouch_coyote", 12];
+	_box addmagazinecargoGlobal ["rhsusf_200rnd_556x45_mixed_box_black", 12];
     _box addmagazinecargoGlobal ["rhsusf_100Rnd_762x51_m80a1epr", 8];
 	_box addmagazinecargoGlobal ["UK3CB_BAF_12G_Pellets", 16];
 	_box addmagazinecargoGlobal ["UK3CB_BAF_12G_Slugs", 16];
@@ -80,7 +80,7 @@ if (_type == 4) then {
 	_box addmagazinecargoGlobal ["tsp_stickCharge_auto_mag", 2];
 	_box addmagazinecargoGlobal ["tsp_frameCharge_mag", 1];
 	_box addmagazinecargoGlobal ["rhs_mag_30Rnd_556x45_M855A1_Stanag_Pull", 36];
-	_box addmagazinecargoGlobal ["rhsusf_200Rnd_556x45_mixed_soft_pouch_coyote", 6];
+	_box addmagazinecargoGlobal ["rhsusf_200rnd_556x45_mixed_box_black", 6];
     _box addmagazinecargoGlobal ["20Rnd_762x51_Mag", 8];
 	_box addmagazinecargoGlobal ["UK3CB_P320_9x19_17Rnd", 8];
 	_box addWeaponCargoGlobal ["rhs_weap_m72a7", 2];

--- a/loadouts/MODERN/T3_CAN_Army/T3_CAN_Army_WD/aWeaponCall.sqf
+++ b/loadouts/MODERN/T3_CAN_Army/T3_CAN_Army_WD/aWeaponCall.sqf
@@ -72,9 +72,9 @@
     //5 - AutoRifle
     if (_Rifle == 5) then{
         _primaryArray = [
-            "rhs_weap_minimi_para_railed"
+            "7r_weap_c9"
         ];
-        _primaryAmmo = "rhsusf_200Rnd_556x45_mixed_soft_pouch_coyote";
+        _primaryAmmo = "rhsusf_200rnd_556x45_mixed_box_black";
     };
 
     //6 - MMG

--- a/loadouts/MODERN/T3_CAN_Army/T3_CAN_Army_WD/can_e_ar.sqf
+++ b/loadouts/MODERN/T3_CAN_Army/T3_CAN_Army_WD/can_e_ar.sqf
@@ -40,7 +40,7 @@ comment "Add Drip";
 comment "Add Weapons/Attachments";
     //1 - Rifle 1 | 2 - Rifle 2 | 3 - Grenadier | 4 - BattleRifle | 5 - AutoRifle | 6 - MMG | 7 - SPC | 8 - DMR
     [_unit, 5] call compile preprocessFileLineNumbers "loadouts\aWeaponCall.sqf";
-    _unit addPrimaryWeaponItem "7r_acc_c79_blk";
+    _unit addPrimaryWeaponItem "7r_acc_c79";
 
 comment "Add Secondary/Attachments";
 

--- a/loadouts/MODERN/T3_CAN_Army/T3_CAN_Army_WD/can_p_ar.sqf
+++ b/loadouts/MODERN/T3_CAN_Army/T3_CAN_Army_WD/can_p_ar.sqf
@@ -40,7 +40,7 @@ comment "Add Drip";
 comment "Add Primary/Attachments";
     // 1 - Rifle 1 | 2 - Rifle 2 | 3 - Grenadier | 4 - BattleRifle | 5 - AutoRifle | 6 - MMG
     [_unit, 5] call compile preprocessFileLineNumbers "loadouts\aWeaponCall.sqf";
-    _unit addPrimaryWeaponItem "7r_acc_c79_blk";
+    _unit addPrimaryWeaponItem "7r_acc_c79";
 
 comment "Add Secondary/Attachments";
 

--- a/loadouts/MODERN/T3_CDF_2020s/T3_CDF_2020s_D/_big_box.sqf
+++ b/loadouts/MODERN/T3_CDF_2020s/T3_CDF_2020s_D/_big_box.sqf
@@ -7,7 +7,7 @@ if(isServer) then {
 	this addmagazinecargoGlobal ["rhs_60Rnd_545X39_7N10_AK_mixed", 160];
 	this addmagazinecargoGlobal ["rhsusf_100Rnd_762x51_m80a1epr", 40];
     this addmagazinecargoGlobal ["rhs_mag_9x18_8_57N181S", 60];
-    this addweaponcargoGlobal ["rhs_weap_rpg26", 20];
+    this addweaponcargoGlobal ["rhs_weap_rpg75", 20];
     this addweaponcargoGlobal ["rhs_weap_rshg2", 10];
 	this addmagazinecargoGlobal ["rhs_rpg7_PG7VL_mag", 20];
 	this addmagazinecargoGlobal ["rhs_rpg7_OG7V_mag", 10];

--- a/loadouts/MODERN/T3_CDF_2020s/T3_CDF_2020s_D/_supply_drop_content.sqf
+++ b/loadouts/MODERN/T3_CDF_2020s/T3_CDF_2020s_D/_supply_drop_content.sqf
@@ -27,8 +27,8 @@ if (_type == 1) then {
 	_box addmagazinecargoGlobal ["rhsusf_8Rnd_Slug", 16];
 	_box addmagazinecargoGlobal ["20Rnd_762x51_Mag", 20];
 	_box addmagazinecargoGlobal ["10Rnd_762x54_Mag", 10];
-	_box addmagazinecargoGlobal ["rhs_20rnd_9x39mm_SP6", 24];
-	_box addWeaponCargoGlobal ["rhs_weap_rpg26", 4];
+	_box addmagazinecargoGlobal ["rhs_30Rnd_762x39mm_Savz58", 24];
+	_box addWeaponCargoGlobal ["rhs_weap_rpg75", 4];
 	_box addWeaponCargoGlobal ["rhs_weap_rshg2", 2];
 	_box addmagazinecargoGlobal ["rhs_rpg7_PG7VL_mag", 3];
 	_box addmagazinecargoGlobal ["rhs_rpg7_PG7VR_mag", 2];
@@ -84,9 +84,9 @@ if (_type == 4) then {
 	_box addmagazinecargoGlobal ["rhs_60Rnd_545X39_7N10_AK_mixed", 6];
     _box addmagazinecargoGlobal ["20Rnd_762x51_Mag", 12];
     _box addmagazinecargoGlobal ["10Rnd_762x54_Mag", 5];
-	_box addmagazinecargoGlobal ["rhs_20rnd_9x39mm_SP6", 12];
+	_box addmagazinecargoGlobal ["rhs_30Rnd_762x39mm_Savz58", 12];
 	_box addmagazinecargoGlobal ["rhs_mag_9x18_8_57N181S", 8];
-	_box addWeaponCargoGlobal ["rhs_weap_rpg26", 2];
+	_box addWeaponCargoGlobal ["rhs_weap_rpg75", 2];
 	_box addWeaponCargoGlobal ["rhs_weap_rshg2", 1];
 	_box additemcargoGlobal ["rhs_mag_rgd5", 6];
 	_box additemcargoGlobal ["rhs_mag_rgo", 2];

--- a/loadouts/MODERN/T3_CDF_2020s/T3_CDF_2020s_D/_uniforms_box.sqf
+++ b/loadouts/MODERN/T3_CDF_2020s/T3_CDF_2020s_D/_uniforms_box.sqf
@@ -29,7 +29,7 @@ _uniforms = [
 		[["Operator Grenadier", "loadouts\cdf_o_Grenadier.sqf"],
 		["Operator DMR", "loadouts\cdf_o_dmr.sqf"],
 		["Operator Battlerifle", "loadouts\cdf_o_br.sqf"],
-		["Operator Specialist (VSS Vintorez)", "loadouts\cdf_o_spec.sqf"],
+		["Operator Specialist (Sa vz. 58)", "loadouts\cdf_o_spec.sqf"],
 		["Operator Breacher", "loadouts\cdf_o_breacher.sqf"],
 		["Operator Engineer (Demo)", "loadouts\cdf_o_e_demo.sqf"],
 		["Operator Engineer (EOD)", "loadouts\cdf_o_e_eod.sqf"],

--- a/loadouts/MODERN/T3_CDF_2020s/T3_CDF_2020s_D/_vehicle_cargo_content.sqf
+++ b/loadouts/MODERN/T3_CDF_2020s/T3_CDF_2020s_D/_vehicle_cargo_content.sqf
@@ -26,7 +26,7 @@ switch (_index) do {
 	// Ground Vehicle (Infantry) Loadout - Loadout 2
 	case 2: {
 		_vehicle additemcargoGlobal ["SR_PAK", 8];
-		_vehicle addWeaponcargoGlobal ["rhs_weap_rpg26", 2];
+		_vehicle addWeaponcargoGlobal ["rhs_weap_rpg75", 2];
 	};
 	// Ground Vehicle (Echo) Loadout - Loadout 3
 	case 3: {

--- a/loadouts/MODERN/T3_CDF_2020s/T3_CDF_2020s_D/aUniformCall.sqf
+++ b/loadouts/MODERN/T3_CDF_2020s/T3_CDF_2020s_D/aUniformCall.sqf
@@ -39,7 +39,7 @@
             "7r_bdu_btisrl_ttsko_d",2,
             "7r_bdu_srl_ttsko_d",4,
             "7r_bdu_srh_ttsko_d",6,
-            "7r_bdu_bnu_ttsko_d",6
+            "7r_bdu_bnu_ttsko_d",3
         ];
     };
 
@@ -55,7 +55,7 @@
             "7r_bdu_btisrl_ttsko_d",2,
             "7r_bdu_srl_ttsko_d",4,
             "7r_bdu_srh_ttsko_d",6,
-            "7r_bdu_bnu_ttsko_d",6
+            "7r_bdu_bnu_ttsko_d",3
         ];
     };
 
@@ -71,7 +71,7 @@
             "7r_bdu_btisrl_ttsko_d",2,
             "7r_bdu_srl_ttsko_d",4,
             "7r_bdu_srh_ttsko_d",6,
-            "7r_bdu_bnu_ttsko_d",6
+            "7r_bdu_bnu_ttsko_d",3
         ];
     };
 

--- a/loadouts/MODERN/T3_CDF_2020s/T3_CDF_2020s_D/aWeaponCall.sqf
+++ b/loadouts/MODERN/T3_CDF_2020s/T3_CDF_2020s_D/aWeaponCall.sqf
@@ -83,7 +83,7 @@
     //5 - AutoRifle
     if (_Rifle == 5) then{
         _primaryArray = [
-            "rhs_weap_rpk74m_npz"
+            "rhs_weap_rpk74m"
         ];
         _primaryAmmo = "rhs_60Rnd_545X39_7N10_AK_mixed";
     };
@@ -99,9 +99,10 @@
     //7 - SPC
     if (_Rifle == 7) then{
         _primaryArray = [
-            "rhs_weap_vss_grip"
+            "rhs_weap_savz58p_rail",
+            "rhs_weap_savz58v_rail"
         ];
-        _primaryAmmo = "rhs_20rnd_9x39mm_SP6";
+        _primaryAmmo = "rhs_30Rnd_762x39mm_Savz58";
     };
 
     //8 - DMR

--- a/loadouts/MODERN/T3_CDF_2020s/T3_CDF_2020s_D/cdf_e_ar.sqf
+++ b/loadouts/MODERN/T3_CDF_2020s/T3_CDF_2020s_D/cdf_e_ar.sqf
@@ -43,6 +43,7 @@ comment "Add Drip";
 comment "Add Weapons/Attachments";
     //1 - Rifle 1 | 2 - Rifle 2 | 3 - Grenadier | 4 - BattleRifle | 5 - AutoRifle | 6 - MMG | 7 - SPC | 8 - DMR
     [_unit, 5] call compile preprocessFileLineNumbers "loadouts\aWeaponCall.sqf";
+    [objNull, _unit] call compile preprocessFileLineNumbers "loadouts\optic_switch.sqf";
     _unit addPrimaryWeaponItem "rhsusf_acc_ELCAN";
 
 comment "Add Secondary/Attachments";

--- a/loadouts/MODERN/T3_CDF_2020s/T3_CDF_2020s_D/cdf_o_lat.sqf
+++ b/loadouts/MODERN/T3_CDF_2020s/T3_CDF_2020s_D/cdf_o_lat.sqf
@@ -48,7 +48,7 @@ comment "Add Secondary/Attachments";
 
 comment "Add Tertiary equipment";
     _unit addWeapon "Binocular";
-    _unit addWeapon "rhs_weap_rpg26";
+    _unit addWeapon "rhs_weap_rpg75";
 
 comment "Add Ammunition";
 

--- a/loadouts/MODERN/T3_CDF_2020s/T3_CDF_2020s_D/cdf_o_lat2.sqf
+++ b/loadouts/MODERN/T3_CDF_2020s/T3_CDF_2020s_D/cdf_o_lat2.sqf
@@ -48,7 +48,7 @@ comment "Add Secondary/Attachments";
 
 comment "Add Tertiary equipment";
     _unit addWeapon "Binocular";
-    _unit addWeapon "rhs_weap_rpg26";
+    _unit addWeapon "rhs_weap_rpg75";
 
 comment "Add Ammunition";
 

--- a/loadouts/MODERN/T3_CDF_2020s/T3_CDF_2020s_D/cdf_p_ar.sqf
+++ b/loadouts/MODERN/T3_CDF_2020s/T3_CDF_2020s_D/cdf_p_ar.sqf
@@ -37,11 +37,12 @@ comment "Add Backpack/Items";
     _unit addBackpack "7r_kitbag_ttsko_d";
 
 comment "Add Drip";
-    _unit addItemToBackpack selectRandomWeighted ["H_Bandanna_sand",1,"H_Cap_headphones",1,"rhsusf_bowman_cap",1,"VSM_Bowman_cap_Tan",1,"rhs_headband",1,"VSM_Beanie_tan",1];
+    _unit addItemToBackpack "7r_ttsko_d_boonie";
 
 comment "Add Primary/Attachments";
     // 1 - Rifle 1 | 2 - Rifle 2 | 3 - Grenadier | 4 - BattleRifle | 5 - AutoRifle | 6 - MMG
     [_unit, 5] call compile preprocessFileLineNumbers "loadouts\aWeaponCall.sqf";
+    [objNull, _unit] call compile preprocessFileLineNumbers "loadouts\optic_switch.sqf";
     _unit addPrimaryWeaponItem "rhsusf_acc_ELCAN";
 
 comment "Add Secondary/Attachments";

--- a/loadouts/MODERN/T3_CDF_2020s/T3_CDF_2020s_D/cdf_p_dmr.sqf
+++ b/loadouts/MODERN/T3_CDF_2020s/T3_CDF_2020s_D/cdf_p_dmr.sqf
@@ -41,7 +41,7 @@ comment "Add Backpack/Items";
     _unit addItemToBackpack "uk3cb_baf_kite";
 
 comment "Add Drip";
-    _unit addItemToBackpack selectRandomWeighted ["H_Bandanna_sand",1,"H_Cap_headphones",1,"rhsusf_bowman_cap",1,"VSM_Bowman_cap_Tan",1,"rhs_headband",1,"VSM_Beanie_tan",1];
+    _unit addItemToBackpack "7r_ttsko_d_boonie";
 
 comment "Add Primary/Attachments";
     // 1 - Rifle 1 | 2 - Rifle 2 | 3 - Grenadier | 4 - BattleRifle | 5 - AutoRifle | 6 - MMG | 7 - SPC | 8 - DMR

--- a/loadouts/MODERN/T3_CDF_2020s/T3_CDF_2020s_D/cdf_p_driver.sqf
+++ b/loadouts/MODERN/T3_CDF_2020s/T3_CDF_2020s_D/cdf_p_driver.sqf
@@ -40,7 +40,7 @@ comment "Add Backpack/Items";
     _unit addItemToBackpack "ACE_EntrenchingTool";
 
 comment "Add Drip";
-    _unit addItemToBackpack selectRandomWeighted ["H_Bandanna_sand",1,"H_Cap_headphones",1,"rhsusf_bowman_cap",1,"VSM_Bowman_cap_Tan",1,"rhs_headband",1,"VSM_Beanie_tan",1];
+    _unit addItemToBackpack "7r_ttsko_d_boonie";
 
 comment "Add Primary/Attachments";
     // 1 - Rifle 1 | 2 - Rifle 2 | 3 - Grenadier | 4 - BattleRifle | 5 - AutoRifle | 6 - MMG

--- a/loadouts/MODERN/T3_CDF_2020s/T3_CDF_2020s_D/cdf_p_medic.sqf
+++ b/loadouts/MODERN/T3_CDF_2020s/T3_CDF_2020s_D/cdf_p_medic.sqf
@@ -40,7 +40,7 @@ comment "Add Backpack/Items";
     _unit addBackpack "7r_carryall_ttsko_d";
 
 comment "Add Drip";
-    _unit addItemToBackpack selectRandomWeighted ["H_Bandanna_sand",1,"H_Cap_headphones",1,"rhsusf_bowman_cap",1,"VSM_Bowman_cap_Tan",1,"rhs_headband",1,"VSM_Beanie_tan",1];
+    _unit addItemToBackpack "7r_ttsko_d_boonie";
 
 comment "Add Primary/Attachments";
     // 1 - Rifle 1 | 2 - Rifle 2 | 3 - Grenadier | 4 - BattleRifle | 5 - AutoRifle | 6 - MMG

--- a/loadouts/MODERN/T3_CDF_2020s/T3_CDF_2020s_D/cdf_s_sniper.sqf
+++ b/loadouts/MODERN/T3_CDF_2020s/T3_CDF_2020s_D/cdf_s_sniper.sqf
@@ -35,7 +35,7 @@ comment "Add Vest/Items";
 
 comment "Add Backpack/Items";
     _unit addBackpack "B_Kitbag_invisible";
-    backpackContainer _unit addWeaponWithAttachmentsCargo [["rhs_weap_vss_grip_npz","","rhs_acc_perst1ik_ris","rhsusf_acc_g33_t1",["rhs_20rnd_9x39mm_SP6",20],[],"rhsusf_acc_rvg_blk"], 1];
+    backpackContainer _unit addWeaponWithAttachmentsCargo [["rhs_weap_vss_grip_npz","","rhs_acc_perst1ik_ris","rhsusf_acc_g33_t1",["rhs_30Rnd_762x39mm_Savz58",20],[],"rhsusf_acc_rvg_blk"], 1];
     _unit addItemToBackpack "Laserbatteries";
     _unit addItemToBackpack "ACE_RangeCard";
     _unit addItemToBackpack "uk3cb_baf_maxikite";
@@ -58,7 +58,7 @@ comment "Add Tertiary equipment";
 
 comment "Add Ammunition";
     for "_i" from 1 to 4 do {_unit addItemToUniform "rhs_mag_9x18_8_57N181S";};
-    for "_i" from 1 to 3 do {_unit addItem "rhs_20rnd_9x39mm_SP6";};
+    for "_i" from 1 to 3 do {_unit addItem "rhs_30Rnd_762x39mm_Savz58";};
     for "_i" from 1 to 10 do {_unit addItemToVest "rhsusf_5Rnd_300winmag_xm2010";};
 
 comment "Add Navigation";

--- a/loadouts/MODERN/T3_CDF_2020s/T3_CDF_2020s_D/optic_switch.sqf
+++ b/loadouts/MODERN/T3_CDF_2020s/T3_CDF_2020s_D/optic_switch.sqf
@@ -38,7 +38,11 @@ _npz_list = [
 	"rhs_weap_rpk74m_npz",
 	"rhs_weap_ak74m_desert_npz",
 	"rhs_weap_m14_rail",
-	"rhs_weap_m14_rail_fiberglass"
+	"rhs_weap_m14_rail_fiberglass",
+	"rhs_weap_savz58p_rail",
+	"rhs_weap_savz58p_rail_black",
+	"rhs_weap_savz58v_rail",
+	"rhs_weap_savz58v_rail_black"
 ];
 
 _dvt_list = [
@@ -71,7 +75,11 @@ _dvt_list = [
 	"rhs_weap_rpk74m",
 	"rhs_weap_ak74m_desert",
 	"rhs_weap_m14",
-	"rhs_weap_m14_fiberglass"
+	"rhs_weap_m14_fiberglass",
+	"rhs_weap_savz58p",
+	"rhs_weap_savz58p_black",
+	"rhs_weap_savz58v",
+	"rhs_weap_savz58v_black"
 ];
 
 if (!(_weapon in _npz_list) && !(_weapon in _dvt_list)) exitWith {};

--- a/loadouts/MODERN/T3_CDF_2020s/T3_CDF_2020s_W/_big_box.sqf
+++ b/loadouts/MODERN/T3_CDF_2020s/T3_CDF_2020s_W/_big_box.sqf
@@ -7,7 +7,7 @@ if(isServer) then {
 	this addmagazinecargoGlobal ["rhs_60Rnd_545X39_7N10_AK_mixed", 160];
 	this addmagazinecargoGlobal ["rhsusf_100Rnd_762x51_m80a1epr", 40];
     this addmagazinecargoGlobal ["rhs_mag_9x18_8_57N181S", 60];
-    this addweaponcargoGlobal ["rhs_weap_rpg26", 20];
+    this addweaponcargoGlobal ["rhs_weap_rpg75", 20];
     this addweaponcargoGlobal ["rhs_weap_rshg2", 10];
 	this addmagazinecargoGlobal ["rhs_rpg7_PG7VL_mag", 20];
 	this addmagazinecargoGlobal ["rhs_rpg7_OG7V_mag", 10];

--- a/loadouts/MODERN/T3_CDF_2020s/T3_CDF_2020s_W/_supply_drop_content.sqf
+++ b/loadouts/MODERN/T3_CDF_2020s/T3_CDF_2020s_W/_supply_drop_content.sqf
@@ -27,8 +27,8 @@ if (_type == 1) then {
 	_box addmagazinecargoGlobal ["rhsusf_8Rnd_Slug", 16];
 	_box addmagazinecargoGlobal ["20Rnd_762x51_Mag", 20];
 	_box addmagazinecargoGlobal ["10Rnd_762x54_Mag", 10];
-	_box addmagazinecargoGlobal ["rhs_20rnd_9x39mm_SP6", 24];
-	_box addWeaponCargoGlobal ["rhs_weap_rpg26", 4];
+	_box addmagazinecargoGlobal ["rhs_30Rnd_762x39mm_Savz58", 24];
+	_box addWeaponCargoGlobal ["rhs_weap_rpg75", 4];
 	_box addWeaponCargoGlobal ["rhs_weap_rshg2", 2];
 	_box addmagazinecargoGlobal ["rhs_rpg7_PG7VL_mag", 3];
 	_box addmagazinecargoGlobal ["rhs_rpg7_PG7VR_mag", 2];
@@ -84,9 +84,9 @@ if (_type == 4) then {
 	_box addmagazinecargoGlobal ["rhs_60Rnd_545X39_7N10_AK_mixed", 6];
     _box addmagazinecargoGlobal ["20Rnd_762x51_Mag", 12];
     _box addmagazinecargoGlobal ["10Rnd_762x54_Mag", 5];
-	_box addmagazinecargoGlobal ["rhs_20rnd_9x39mm_SP6", 12];
+	_box addmagazinecargoGlobal ["rhs_30Rnd_762x39mm_Savz58", 12];
 	_box addmagazinecargoGlobal ["rhs_mag_9x18_8_57N181S", 8];
-	_box addWeaponCargoGlobal ["rhs_weap_rpg26", 2];
+	_box addWeaponCargoGlobal ["rhs_weap_rpg75", 2];
 	_box addWeaponCargoGlobal ["rhs_weap_rshg2", 1];
 	_box additemcargoGlobal ["rhs_mag_rgd5", 6];
 	_box additemcargoGlobal ["rhs_mag_rgo", 2];

--- a/loadouts/MODERN/T3_CDF_2020s/T3_CDF_2020s_W/_uniforms_box.sqf
+++ b/loadouts/MODERN/T3_CDF_2020s/T3_CDF_2020s_W/_uniforms_box.sqf
@@ -29,7 +29,7 @@ _uniforms = [
 		[["Operator Grenadier", "loadouts\cdf_o_Grenadier.sqf"],
 		["Operator DMR", "loadouts\cdf_o_dmr.sqf"],
 		["Operator Battlerifle", "loadouts\cdf_o_br.sqf"],
-		["Operator Specialist (VSS Vintorez)", "loadouts\cdf_o_spec.sqf"],
+		["Operator Specialist (Sa vz. 58)", "loadouts\cdf_o_spec.sqf"],
 		["Operator Breacher", "loadouts\cdf_o_breacher.sqf"],
 		["Operator Engineer (Demo)", "loadouts\cdf_o_e_demo.sqf"],
 		["Operator Engineer (EOD)", "loadouts\cdf_o_e_eod.sqf"],

--- a/loadouts/MODERN/T3_CDF_2020s/T3_CDF_2020s_W/_vehicle_cargo_content.sqf
+++ b/loadouts/MODERN/T3_CDF_2020s/T3_CDF_2020s_W/_vehicle_cargo_content.sqf
@@ -26,7 +26,7 @@ switch (_index) do {
 	// Ground Vehicle (Infantry) Loadout - Loadout 2
 	case 2: {
 		_vehicle additemcargoGlobal ["SR_PAK", 8];
-		_vehicle addWeaponcargoGlobal ["rhs_weap_rpg26", 2];
+		_vehicle addWeaponcargoGlobal ["rhs_weap_rpg75", 2];
 	};
 	// Ground Vehicle (Echo) Loadout - Loadout 3
 	case 3: {

--- a/loadouts/MODERN/T3_CDF_2020s/T3_CDF_2020s_W/aWeaponCall.sqf
+++ b/loadouts/MODERN/T3_CDF_2020s/T3_CDF_2020s_W/aWeaponCall.sqf
@@ -83,7 +83,7 @@
     //5 - AutoRifle
     if (_Rifle == 5) then{
         _primaryArray = [
-            "rhs_weap_rpk74m_npz"
+            "rhs_weap_rpk74m"
         ];
         _primaryAmmo = "rhs_60Rnd_545X39_7N10_AK_mixed";
     };
@@ -99,9 +99,10 @@
     //7 - SPC
     if (_Rifle == 7) then{
         _primaryArray = [
-            "rhs_weap_vss_grip"
+            "rhs_weap_savz58p_rail",
+            "rhs_weap_savz58v_rail"
         ];
-        _primaryAmmo = "rhs_20rnd_9x39mm_SP6";
+        _primaryAmmo = "rhs_30Rnd_762x39mm_Savz58";
     };
 
     //8 - DMR

--- a/loadouts/MODERN/T3_CDF_2020s/T3_CDF_2020s_W/cdf_e_ar.sqf
+++ b/loadouts/MODERN/T3_CDF_2020s/T3_CDF_2020s_W/cdf_e_ar.sqf
@@ -49,6 +49,7 @@ comment "Add Drip";
 comment "Add Weapons/Attachments";
     //1 - Rifle 1 | 2 - Rifle 2 | 3 - Grenadier | 4 - BattleRifle | 5 - AutoRifle | 6 - MMG | 7 - SPC | 8 - DMR
     [_unit, 5] call compile preprocessFileLineNumbers "loadouts\aWeaponCall.sqf";
+    [objNull, _unit] call compile preprocessFileLineNumbers "loadouts\optic_switch.sqf";
     _unit addPrimaryWeaponItem "rhsusf_acc_ELCAN";
 
 comment "Add Secondary/Attachments";

--- a/loadouts/MODERN/T3_CDF_2020s/T3_CDF_2020s_W/cdf_o_lat.sqf
+++ b/loadouts/MODERN/T3_CDF_2020s/T3_CDF_2020s_W/cdf_o_lat.sqf
@@ -54,7 +54,7 @@ comment "Add Secondary/Attachments";
 
 comment "Add Tertiary equipment";
     _unit addWeapon "Binocular";
-    _unit addWeapon "rhs_weap_rpg26";
+    _unit addWeapon "rhs_weap_rpg75";
 
 comment "Add Ammunition";
 

--- a/loadouts/MODERN/T3_CDF_2020s/T3_CDF_2020s_W/cdf_o_lat2.sqf
+++ b/loadouts/MODERN/T3_CDF_2020s/T3_CDF_2020s_W/cdf_o_lat2.sqf
@@ -54,7 +54,7 @@ comment "Add Secondary/Attachments";
 
 comment "Add Tertiary equipment";
     _unit addWeapon "Binocular";
-    _unit addWeapon "rhs_weap_rpg26";
+    _unit addWeapon "rhs_weap_rpg75";
 
 comment "Add Ammunition";
 

--- a/loadouts/MODERN/T3_CDF_2020s/T3_CDF_2020s_W/cdf_p_ar.sqf
+++ b/loadouts/MODERN/T3_CDF_2020s/T3_CDF_2020s_W/cdf_p_ar.sqf
@@ -49,6 +49,7 @@ comment "Add Drip";
 comment "Add Primary/Attachments";
     // 1 - Rifle 1 | 2 - Rifle 2 | 3 - Grenadier | 4 - BattleRifle | 5 - AutoRifle | 6 - MMG
     [_unit, 5] call compile preprocessFileLineNumbers "loadouts\aWeaponCall.sqf";
+    [objNull, _unit] call compile preprocessFileLineNumbers "loadouts\optic_switch.sqf";
     _unit addPrimaryWeaponItem "rhsusf_acc_ELCAN";
 
 comment "Add Secondary/Attachments";

--- a/loadouts/MODERN/T3_CDF_2020s/T3_CDF_2020s_W/cdf_s_sniper.sqf
+++ b/loadouts/MODERN/T3_CDF_2020s/T3_CDF_2020s_W/cdf_s_sniper.sqf
@@ -35,7 +35,7 @@ comment "Add Vest/Items";
 
 comment "Add Backpack/Items";
     _unit addBackpack "B_Kitbag_invisible";
-    backpackContainer _unit addWeaponWithAttachmentsCargo [["rhs_weap_vss_grip_npz","","rhs_acc_perst1ik_ris","rhsusf_acc_g33_t1",["rhs_20rnd_9x39mm_SP6",20],[],"rhsusf_acc_rvg_blk"], 1];
+    backpackContainer _unit addWeaponWithAttachmentsCargo [["rhs_weap_vss_grip_npz","","rhs_acc_perst1ik_ris","rhsusf_acc_g33_t1",["rhs_30Rnd_762x39mm_Savz58",20],[],"rhsusf_acc_rvg_blk"], 1];
     _unit addItemToBackpack "Laserbatteries";
     _unit addItemToBackpack "ACE_RangeCard";
     _unit addItemToBackpack "uk3cb_baf_maxikite";
@@ -58,7 +58,7 @@ comment "Add Tertiary equipment";
 
 comment "Add Ammunition";
     for "_i" from 1 to 4 do {_unit addItemToUniform "rhs_mag_9x18_8_57N181S";};
-    for "_i" from 1 to 3 do {_unit addItem "rhs_20rnd_9x39mm_SP6";};
+    for "_i" from 1 to 3 do {_unit addItem "rhs_30Rnd_762x39mm_Savz58";};
     for "_i" from 1 to 10 do {_unit addItemToVest "rhsusf_5Rnd_300winmag_xm2010";};
 
 comment "Add Navigation";

--- a/loadouts/MODERN/T3_CDF_2020s/T3_CDF_2020s_W/optic_switch.sqf
+++ b/loadouts/MODERN/T3_CDF_2020s/T3_CDF_2020s_W/optic_switch.sqf
@@ -38,7 +38,11 @@ _npz_list = [
 	"rhs_weap_rpk74m_npz",
 	"rhs_weap_ak74m_desert_npz",
 	"rhs_weap_m14_rail",
-	"rhs_weap_m14_rail_fiberglass"
+	"rhs_weap_m14_rail_fiberglass",
+	"rhs_weap_savz58p_rail",
+	"rhs_weap_savz58p_rail_black",
+	"rhs_weap_savz58v_rail",
+	"rhs_weap_savz58v_rail_black"
 ];
 
 _dvt_list = [
@@ -71,7 +75,11 @@ _dvt_list = [
 	"rhs_weap_rpk74m",
 	"rhs_weap_ak74m_desert",
 	"rhs_weap_m14",
-	"rhs_weap_m14_fiberglass"
+	"rhs_weap_m14_fiberglass",
+	"rhs_weap_savz58p",
+	"rhs_weap_savz58p_black",
+	"rhs_weap_savz58v",
+	"rhs_weap_savz58v_black"
 ];
 
 if (!(_weapon in _npz_list) && !(_weapon in _dvt_list)) exitWith {};

--- a/loadouts/MODERN/T3_CDF_2020s/T3_CDF_2020s_WD/_big_box.sqf
+++ b/loadouts/MODERN/T3_CDF_2020s/T3_CDF_2020s_WD/_big_box.sqf
@@ -7,7 +7,7 @@ if(isServer) then {
 	this addmagazinecargoGlobal ["rhs_60Rnd_545X39_7N10_AK_mixed", 160];
 	this addmagazinecargoGlobal ["rhsusf_100Rnd_762x51_m80a1epr", 40];
     this addmagazinecargoGlobal ["rhs_mag_9x18_8_57N181S", 60];
-    this addweaponcargoGlobal ["rhs_weap_rpg26", 20];
+    this addweaponcargoGlobal ["rhs_weap_rpg75", 20];
     this addweaponcargoGlobal ["rhs_weap_rshg2", 10];
 	this addmagazinecargoGlobal ["rhs_rpg7_PG7VL_mag", 20];
 	this addmagazinecargoGlobal ["rhs_rpg7_OG7V_mag", 10];

--- a/loadouts/MODERN/T3_CDF_2020s/T3_CDF_2020s_WD/_supply_drop_content.sqf
+++ b/loadouts/MODERN/T3_CDF_2020s/T3_CDF_2020s_WD/_supply_drop_content.sqf
@@ -27,8 +27,8 @@ if (_type == 1) then {
 	_box addmagazinecargoGlobal ["rhsusf_8Rnd_Slug", 16];
 	_box addmagazinecargoGlobal ["20Rnd_762x51_Mag", 20];
 	_box addmagazinecargoGlobal ["10Rnd_762x54_Mag", 10];
-	_box addmagazinecargoGlobal ["rhs_20rnd_9x39mm_SP6", 24];
-	_box addWeaponCargoGlobal ["rhs_weap_rpg26", 4];
+	_box addmagazinecargoGlobal ["rhs_30Rnd_762x39mm_Savz58", 24];
+	_box addWeaponCargoGlobal ["rhs_weap_rpg75", 4];
 	_box addWeaponCargoGlobal ["rhs_weap_rshg2", 2];
 	_box addmagazinecargoGlobal ["rhs_rpg7_PG7VL_mag", 3];
 	_box addmagazinecargoGlobal ["rhs_rpg7_PG7VR_mag", 2];
@@ -84,9 +84,9 @@ if (_type == 4) then {
 	_box addmagazinecargoGlobal ["rhs_60Rnd_545X39_7N10_AK_mixed", 6];
     _box addmagazinecargoGlobal ["20Rnd_762x51_Mag", 12];
     _box addmagazinecargoGlobal ["10Rnd_762x54_Mag", 5];
-	_box addmagazinecargoGlobal ["rhs_20rnd_9x39mm_SP6", 12];
+	_box addmagazinecargoGlobal ["rhs_30Rnd_762x39mm_Savz58", 12];
 	_box addmagazinecargoGlobal ["rhs_mag_9x18_8_57N181S", 8];
-	_box addWeaponCargoGlobal ["rhs_weap_rpg26", 2];
+	_box addWeaponCargoGlobal ["rhs_weap_rpg75", 2];
 	_box addWeaponCargoGlobal ["rhs_weap_rshg2", 1];
 	_box additemcargoGlobal ["rhs_mag_rgd5", 6];
 	_box additemcargoGlobal ["rhs_mag_rgo", 2];

--- a/loadouts/MODERN/T3_CDF_2020s/T3_CDF_2020s_WD/_uniforms_box.sqf
+++ b/loadouts/MODERN/T3_CDF_2020s/T3_CDF_2020s_WD/_uniforms_box.sqf
@@ -29,7 +29,7 @@ _uniforms = [
 		[["Operator Grenadier", "loadouts\cdf_o_Grenadier.sqf"],
 		["Operator DMR", "loadouts\cdf_o_dmr.sqf"],
 		["Operator Battlerifle", "loadouts\cdf_o_br.sqf"],
-		["Operator Specialist (VSS Vintorez)", "loadouts\cdf_o_spec.sqf"],
+		["Operator Specialist (Sa vz. 58)", "loadouts\cdf_o_spec.sqf"],
 		["Operator Breacher", "loadouts\cdf_o_breacher.sqf"],
 		["Operator Engineer (Demo)", "loadouts\cdf_o_e_demo.sqf"],
 		["Operator Engineer (EOD)", "loadouts\cdf_o_e_eod.sqf"],

--- a/loadouts/MODERN/T3_CDF_2020s/T3_CDF_2020s_WD/_vehicle_cargo_content.sqf
+++ b/loadouts/MODERN/T3_CDF_2020s/T3_CDF_2020s_WD/_vehicle_cargo_content.sqf
@@ -26,7 +26,7 @@ switch (_index) do {
 	// Ground Vehicle (Infantry) Loadout - Loadout 2
 	case 2: {
 		_vehicle additemcargoGlobal ["SR_PAK", 8];
-		_vehicle addWeaponcargoGlobal ["rhs_weap_rpg26", 2];
+		_vehicle addWeaponcargoGlobal ["rhs_weap_rpg75", 2];
 	};
 	// Ground Vehicle (Echo) Loadout - Loadout 3
 	case 3: {

--- a/loadouts/MODERN/T3_CDF_2020s/T3_CDF_2020s_WD/aUniformCall.sqf
+++ b/loadouts/MODERN/T3_CDF_2020s/T3_CDF_2020s_WD/aUniformCall.sqf
@@ -30,48 +30,48 @@
     //Echo
     if (_Class == 1) then{
         _uniformArray = [
-            "7r_combatsmocks_ttsko",4,
-            "7r_combatsmocks_ttsko_gloves",4,
-            "7r_combatsmocks_ttsko_odg",4,
-            "7r_combatsmocks_ttsko_odg_gloves",4,
+            "7r_combatsmocks_ttsko",5,
+            "7r_combatsmocks_ttsko_gloves",5,
+            "7r_combatsmocks_ttsko_odg",5,
+            "7r_combatsmocks_ttsko_odg_gloves",5,
             "7r_bdu_ttsko",2,
-            "7r_bdu_bti_ttsko",1,
-            "7r_bdu_btisrl_ttsko",1,
+            "7r_bdu_bti_ttsko",2,
+            "7r_bdu_btisrl_ttsko",2,
             "7r_bdu_srl_ttsko",2,
-            "7r_bdu_srh_ttsko",3,
-            "7r_bdu_bnu_ttsko",3
+            "7r_bdu_srh_ttsko",2,
+            "7r_bdu_bnu_ttsko",2
         ];
     };
 
     //Squad
     if (_Class == 2) then{
         _uniformArray = [
-            "7r_combatsmocks_ttsko",4,
-            "7r_combatsmocks_ttsko_gloves",4,
-            "7r_combatsmocks_ttsko_odg",4,
-            "7r_combatsmocks_ttsko_odg_gloves",4,
+            "7r_combatsmocks_ttsko",5,
+            "7r_combatsmocks_ttsko_gloves",5,
+            "7r_combatsmocks_ttsko_odg",5,
+            "7r_combatsmocks_ttsko_odg_gloves",5,
             "7r_bdu_ttsko",2,
-            "7r_bdu_bti_ttsko",1,
-            "7r_bdu_btisrl_ttsko",1,
+            "7r_bdu_bti_ttsko",2,
+            "7r_bdu_btisrl_ttsko",2,
             "7r_bdu_srl_ttsko",2,
-            "7r_bdu_srh_ttsko",3,
-            "7r_bdu_bnu_ttsko",3
+            "7r_bdu_srh_ttsko",2,
+            "7r_bdu_bnu_ttsko",2
         ];
     };
 
     //Platoon 
     if (_Class == 3) then{
         _uniformArray = [
-            "7r_combatsmocks_ttsko",4,
-            "7r_combatsmocks_ttsko_gloves",4,
-            "7r_combatsmocks_ttsko_odg",4,
-            "7r_combatsmocks_ttsko_odg_gloves",4,
+            "7r_combatsmocks_ttsko",5,
+            "7r_combatsmocks_ttsko_gloves",5,
+            "7r_combatsmocks_ttsko_odg",5,
+            "7r_combatsmocks_ttsko_odg_gloves",5,
             "7r_bdu_ttsko",2,
-            "7r_bdu_bti_ttsko",1,
-            "7r_bdu_btisrl_ttsko",1,
+            "7r_bdu_bti_ttsko",2,
+            "7r_bdu_btisrl_ttsko",2,
             "7r_bdu_srl_ttsko",2,
-            "7r_bdu_srh_ttsko",3,
-            "7r_bdu_bnu_ttsko",3
+            "7r_bdu_srh_ttsko",2,
+            "7r_bdu_bnu_ttsko",2
         ];
     };
 

--- a/loadouts/MODERN/T3_CDF_2020s/T3_CDF_2020s_WD/aWeaponCall.sqf
+++ b/loadouts/MODERN/T3_CDF_2020s/T3_CDF_2020s_WD/aWeaponCall.sqf
@@ -83,7 +83,7 @@
     //5 - AutoRifle
     if (_Rifle == 5) then{
         _primaryArray = [
-            "rhs_weap_rpk74m_npz"
+            "rhs_weap_rpk74m"
         ];
         _primaryAmmo = "rhs_60Rnd_545X39_7N10_AK_mixed";
     };
@@ -99,9 +99,10 @@
     //7 - SPC
     if (_Rifle == 7) then{
         _primaryArray = [
-            "rhs_weap_vss_grip"
+            "rhs_weap_savz58p_rail",
+            "rhs_weap_savz58v_rail"
         ];
-        _primaryAmmo = "rhs_20rnd_9x39mm_SP6";
+        _primaryAmmo = "rhs_30Rnd_762x39mm_Savz58";
     };
 
     //8 - DMR

--- a/loadouts/MODERN/T3_CDF_2020s/T3_CDF_2020s_WD/cdf_e_ar.sqf
+++ b/loadouts/MODERN/T3_CDF_2020s/T3_CDF_2020s_WD/cdf_e_ar.sqf
@@ -43,6 +43,7 @@ comment "Add Drip";
 comment "Add Weapons/Attachments";
     //1 - Rifle 1 | 2 - Rifle 2 | 3 - Grenadier | 4 - BattleRifle | 5 - AutoRifle | 6 - MMG | 7 - SPC | 8 - DMR
     [_unit, 5] call compile preprocessFileLineNumbers "loadouts\aWeaponCall.sqf";
+    [objNull, _unit] call compile preprocessFileLineNumbers "loadouts\optic_switch.sqf";
     _unit addPrimaryWeaponItem "rhsusf_acc_ELCAN";
 
 comment "Add Secondary/Attachments";

--- a/loadouts/MODERN/T3_CDF_2020s/T3_CDF_2020s_WD/cdf_o_lat.sqf
+++ b/loadouts/MODERN/T3_CDF_2020s/T3_CDF_2020s_WD/cdf_o_lat.sqf
@@ -48,7 +48,7 @@ comment "Add Secondary/Attachments";
 
 comment "Add Tertiary equipment";
     _unit addWeapon "Binocular";
-    _unit addWeapon "rhs_weap_rpg26";
+    _unit addWeapon "rhs_weap_rpg75";
 
 comment "Add Ammunition";
 

--- a/loadouts/MODERN/T3_CDF_2020s/T3_CDF_2020s_WD/cdf_o_lat2.sqf
+++ b/loadouts/MODERN/T3_CDF_2020s/T3_CDF_2020s_WD/cdf_o_lat2.sqf
@@ -48,7 +48,7 @@ comment "Add Secondary/Attachments";
 
 comment "Add Tertiary equipment";
     _unit addWeapon "Binocular";
-    _unit addWeapon "rhs_weap_rpg26";
+    _unit addWeapon "rhs_weap_rpg75";
 
 comment "Add Ammunition";
 

--- a/loadouts/MODERN/T3_CDF_2020s/T3_CDF_2020s_WD/cdf_p_ar.sqf
+++ b/loadouts/MODERN/T3_CDF_2020s/T3_CDF_2020s_WD/cdf_p_ar.sqf
@@ -37,11 +37,12 @@ comment "Add Backpack/Items";
     _unit addBackpack "7r_kitbag_ttsko";
 
 comment "Add Drip";
-    _unit addItemToBackpack "rhssaf_booniehat_digital";
+    _unit addItemToBackpack "7r_ttsko_boonie";
 
 comment "Add Primary/Attachments";
     // 1 - Rifle 1 | 2 - Rifle 2 | 3 - Grenadier | 4 - BattleRifle | 5 - AutoRifle | 6 - MMG
     [_unit, 5] call compile preprocessFileLineNumbers "loadouts\aWeaponCall.sqf";
+    [objNull, _unit] call compile preprocessFileLineNumbers "loadouts\optic_switch.sqf";
     _unit addPrimaryWeaponItem "rhsusf_acc_ELCAN";
 
 comment "Add Secondary/Attachments";

--- a/loadouts/MODERN/T3_CDF_2020s/T3_CDF_2020s_WD/cdf_p_dmr.sqf
+++ b/loadouts/MODERN/T3_CDF_2020s/T3_CDF_2020s_WD/cdf_p_dmr.sqf
@@ -41,7 +41,7 @@ comment "Add Backpack/Items";
     _unit addItemToBackpack "uk3cb_baf_kite";
 
 comment "Add Drip";
-    _unit addItemToBackpack "rhssaf_booniehat_digital";
+    _unit addItemToBackpack "7r_ttsko_boonie";
 
 comment "Add Primary/Attachments";
     // 1 - Rifle 1 | 2 - Rifle 2 | 3 - Grenadier | 4 - BattleRifle | 5 - AutoRifle | 6 - MMG | 7 - SPC | 8 - DMR

--- a/loadouts/MODERN/T3_CDF_2020s/T3_CDF_2020s_WD/cdf_p_driver.sqf
+++ b/loadouts/MODERN/T3_CDF_2020s/T3_CDF_2020s_WD/cdf_p_driver.sqf
@@ -40,7 +40,7 @@ comment "Add Backpack/Items";
     _unit addItemToBackpack "ACE_EntrenchingTool";
 
 comment "Add Drip";
-    _unit addItemToBackpack "rhssaf_booniehat_digital";
+    _unit addItemToBackpack "7r_ttsko_boonie";
 
 comment "Add Primary/Attachments";
     // 1 - Rifle 1 | 2 - Rifle 2 | 3 - Grenadier | 4 - BattleRifle | 5 - AutoRifle | 6 - MMG

--- a/loadouts/MODERN/T3_CDF_2020s/T3_CDF_2020s_WD/cdf_p_medic.sqf
+++ b/loadouts/MODERN/T3_CDF_2020s/T3_CDF_2020s_WD/cdf_p_medic.sqf
@@ -40,7 +40,7 @@ comment "Add Backpack/Items";
     _unit addBackpack "7r_carryall_ttsko";
 
 comment "Add Drip";
-    _unit addItemToBackpack "rhssaf_booniehat_digital";
+    _unit addItemToBackpack "7r_ttsko_boonie";
 
 comment "Add Primary/Attachments";
     // 1 - Rifle 1 | 2 - Rifle 2 | 3 - Grenadier | 4 - BattleRifle | 5 - AutoRifle | 6 - MMG

--- a/loadouts/MODERN/T3_CDF_2020s/T3_CDF_2020s_WD/cdf_s_sniper.sqf
+++ b/loadouts/MODERN/T3_CDF_2020s/T3_CDF_2020s_WD/cdf_s_sniper.sqf
@@ -35,7 +35,7 @@ comment "Add Vest/Items";
 
 comment "Add Backpack/Items";
     _unit addBackpack "B_Kitbag_invisible";
-    backpackContainer _unit addWeaponWithAttachmentsCargo [["rhs_weap_vss_grip_npz","","rhs_acc_perst1ik_ris","rhsusf_acc_g33_t1",["rhs_20rnd_9x39mm_SP6",20],[],"rhsusf_acc_rvg_blk"], 1];
+    backpackContainer _unit addWeaponWithAttachmentsCargo [["rhs_weap_vss_grip_npz","","rhs_acc_perst1ik_ris","rhsusf_acc_g33_t1",["rhs_30Rnd_762x39mm_Savz58",20],[],"rhsusf_acc_rvg_blk"], 1];
     _unit addItemToBackpack "Laserbatteries";
     _unit addItemToBackpack "ACE_RangeCard";
     _unit addItemToBackpack "uk3cb_baf_maxikite";
@@ -58,7 +58,7 @@ comment "Add Tertiary equipment";
 
 comment "Add Ammunition";
     for "_i" from 1 to 4 do {_unit addItemToUniform "rhs_mag_9x18_8_57N181S";};
-    for "_i" from 1 to 3 do {_unit addItem "rhs_20rnd_9x39mm_SP6";};
+    for "_i" from 1 to 3 do {_unit addItem "rhs_30Rnd_762x39mm_Savz58";};
     for "_i" from 1 to 10 do {_unit addItemToVest "rhsusf_5Rnd_300winmag_xm2010";};
 
 comment "Add Navigation";

--- a/loadouts/MODERN/T3_CDF_2020s/T3_CDF_2020s_WD/optic_switch.sqf
+++ b/loadouts/MODERN/T3_CDF_2020s/T3_CDF_2020s_WD/optic_switch.sqf
@@ -38,7 +38,11 @@ _npz_list = [
 	"rhs_weap_rpk74m_npz",
 	"rhs_weap_ak74m_desert_npz",
 	"rhs_weap_m14_rail",
-	"rhs_weap_m14_rail_fiberglass"
+	"rhs_weap_m14_rail_fiberglass",
+	"rhs_weap_savz58p_rail",
+	"rhs_weap_savz58p_rail_black",
+	"rhs_weap_savz58v_rail",
+	"rhs_weap_savz58v_rail_black"
 ];
 
 _dvt_list = [
@@ -71,7 +75,11 @@ _dvt_list = [
 	"rhs_weap_rpk74m",
 	"rhs_weap_ak74m_desert",
 	"rhs_weap_m14",
-	"rhs_weap_m14_fiberglass"
+	"rhs_weap_m14_fiberglass",
+	"rhs_weap_savz58p",
+	"rhs_weap_savz58p_black",
+	"rhs_weap_savz58v",
+	"rhs_weap_savz58v_black"
 ];
 
 if (!(_weapon in _npz_list) && !(_weapon in _dvt_list)) exitWith {};

--- a/loadouts/MODERN/T3_FRA_Land_Army/T3_FRA_Land_Army_WD/fra_f_com.sqf
+++ b/loadouts/MODERN/T3_FRA_Land_Army/T3_FRA_Land_Army_WD/fra_f_com.sqf
@@ -14,7 +14,7 @@ removeHeadgear _unit;
 removeGoggles _unit;
 
 comment "Add Uniforms/Items";
-    _unit forceAddUniform selectRandom ["7r_combat_fatigues_daguet_gloves","7r_combat_fatigues_daguet_gloves","7r_combat_fatigues_serval_gloves"];
+    _unit forceAddUniform "7r_combat_fatigues_cce_gloves";
     _unit addItemToUniform "ACE_MapTools";
     _unit addItemToUniform "SR_PAK";
     _unit addItemToUniform "CBRN_gasmaskFilter";
@@ -33,7 +33,7 @@ comment "Add Vest/Items";
 comment "Add Backpack/Items";
 
 comment "Add Drip";
-    _unit addHeadgear "rhsusf_cvc_alt_helmet";
+    _unit addHeadgear "rhsusf_cvc_green_alt_helmet";
     _unit addGoggles "rhsusf_oakley_goggles_clr";
 
 comment "Add Primary/Attachments";

--- a/loadouts/MODERN/T3_FRA_Land_Army/T3_FRA_Land_Army_WD/fra_f_crew.sqf
+++ b/loadouts/MODERN/T3_FRA_Land_Army/T3_FRA_Land_Army_WD/fra_f_crew.sqf
@@ -14,7 +14,7 @@ removeHeadgear _unit;
 removeGoggles _unit;
 
 comment "Add Uniforms/Items";
-    _unit forceAddUniform selectRandom ["7r_combat_fatigues_daguet_gloves","7r_combat_fatigues_daguet_gloves","7r_combat_fatigues_serval_gloves"];
+    _unit forceAddUniform "7r_combat_fatigues_cce_gloves";
     _unit addItemToUniform "ACE_MapTools";
     _unit addItemToUniform "SR_PAK";
     _unit addItemToUniform "CBRN_gasmaskFilter";
@@ -33,7 +33,7 @@ comment "Add Vest/Items";
 comment "Add Backpack/Items";
 
 comment "Add Drip";
-    _unit addHeadgear "rhsusf_cvc_ess";
+    _unit addHeadgear "rhsusf_cvc_green_ess";
 
 comment "Add Primary/Attachments";
     _unit addWeapon "rhs_weap_hk416d10";

--- a/loadouts/MODERN/T3_FRA_Land_Army/T3_FRA_Land_Army_WD/fra_f_tech.sqf
+++ b/loadouts/MODERN/T3_FRA_Land_Army/T3_FRA_Land_Army_WD/fra_f_tech.sqf
@@ -14,7 +14,7 @@ removeHeadgear _unit;
 removeGoggles _unit;
 
 comment "Add Uniforms/Items";
-    _unit forceAddUniform selectRandom ["7r_combat_fatigues_daguet_gloves","7r_combat_fatigues_daguet_gloves","7r_combat_fatigues_serval_gloves"];
+    _unit forceAddUniform "7r_combat_fatigues_cce_gloves";
     _unit addItemToUniform "ACE_MapTools";
     _unit addItemToUniform "SR_PAK";
     _unit addItemToUniform "CBRN_gasmaskFilter";
@@ -35,7 +35,7 @@ comment "Add Backpack/Items";
     _unit addItemToBackpack "ToolKit";
 
 comment "Add Drip";
-    _unit addHeadgear "rhsusf_cvc_alt_helmet";
+    _unit addHeadgear "rhsusf_cvc_green_alt_helmet";
 
 comment "Add Primary/Attachments";
     _unit addWeapon "rhs_weap_hk416d10";


### PR DESCRIPTION
- Replaced generic FN Minimi with L110A3 and C9A2 in BAF and CAF loadouts respectively
- Replaced RPK-74M (NPZ) with RPK-74M where applicable in CDF loadouts
- Replaced VSS Vintorez with Sa vz. 58 in CDF loadouts
- Replaced RPG-26 with RPG-75 in CDF loadouts
- Fixed wrong camo for French Land Army vehicle crew kits.