### PR TITLE
Fix waypoint deletion, dismounts, and exfil logic

### DIFF
--- a/Framework Files/7R/AI/Common/fn_createWaypoint.sqf
+++ b/Framework Files/7R/AI/Common/fn_createWaypoint.sqf
@@ -67,7 +67,7 @@ switch (_type) do
 
 // Waypoint exclusivity
 if (_exclusiv) then {
-	{deleteWaypoint _x} forEach waypoints _group;
+	{deleteWaypoint _x} forEachReversed waypoints _group;
 } else {
 	_waypointNumber = (count (waypoints _group)) + 1;
 };

--- a/Framework Files/7R/AI/Common/fn_dismountVehicle.sqf
+++ b/Framework Files/7R/AI/Common/fn_dismountVehicle.sqf
@@ -11,7 +11,7 @@
 
 */
 // Parameter Init
-params ["_leader","_patrolParams",["_cargo",[]],["_groupSize",4]];
+params ["_leader","_patrolParams",["_cargo",[]],["_groupSize",8],["_rtb",false],["_rtbPos",[0,0,0]]];
 _v = vehicle _leader;
 _originalGroup = group _leader;
 _originalGroup setVariable ["Vcm_Disable",true,true]; 
@@ -95,16 +95,21 @@ if (isNull (gunner vehicle _leader) && !(_v isKindOf "Air")) then {
 
 		// Force loiter altitude to 150m AGL
     	_v flyInHeight 150;
-
-		// Add LOITER waypoint at center
-		{deleteWaypoint _x} forEachReversed waypoints _originalGroup;
-		private _wp = _originalGroup addWaypoint [_paCenter, 0, 1];
-		_wp setWaypointType "LOITER";
-		_wp setWaypointLoiterType "CIRCLE";
-		_wp setWaypointLoiterRadius _paRadius;
-		_wp setWaypointBehaviour "SAFE";
-		_wp setWaypointSpeed "NORMAL";
-		_wp setWaypointCombatMode "WHITE";
+		if (_rtb) then {
+			_dir = (getPos (leader _originalGroup)) getDir _rtbPos;
+			_rtbWP = _rtbPos getPos [3000, _dir];
+			[_originalGroup, _rtbWP, "END"] call fw_fnc_createWaypoint;
+		} else {
+			// Add LOITER waypoint at center
+			{deleteWaypoint _x} forEachReversed waypoints _originalGroup;
+			private _wp = _originalGroup addWaypoint [_paCenter, 0, 1];
+			_wp setWaypointType "LOITER";
+			_wp setWaypointLoiterType "CIRCLE";
+			_wp setWaypointLoiterRadius _paRadius;
+			_wp setWaypointBehaviour "SAFE";
+			_wp setWaypointSpeed "NORMAL";
+			_wp setWaypointCombatMode "WHITE";
+		};
 	} else {
 		_array2 remoteExec ["fw_fnc_patrol", 2];
 	};

--- a/Framework Files/7R/AI/Common/fn_dismountVehicle.sqf
+++ b/Framework Files/7R/AI/Common/fn_dismountVehicle.sqf
@@ -14,9 +14,9 @@
 params ["_leader","_patrolParams",["_cargo",[]],["_groupSize",4]];
 _v = vehicle _leader;
 _originalGroup = group _leader;
-_originalGroup setVariable ["Vcm_Disable",false,true]; 
+_originalGroup setVariable ["Vcm_Disable",true,true]; 
 
-// Check if Vehicle is Armed
+// If vehicle is unarmed, then:
 if (isNull (gunner vehicle _leader) && !(_v isKindOf "Air")) then {
 	// Single Group Dismount
 	units _originalGroup orderGetIn false;
@@ -38,7 +38,7 @@ if (isNull (gunner vehicle _leader) && !(_v isKindOf "Air")) then {
 	};
 
 	// Call UPSMON
-	_array = [_leader];
+	_array = [leader _originalGroup]; //leader might have changed, so grabbing again
 	_array append _patrolParams;
 	_array remoteExec ["fw_fnc_patrol",2];
 } else {
@@ -76,16 +76,36 @@ if (isNull (gunner vehicle _leader) && !(_v isKindOf "Air")) then {
 		if (count _cargo == 0) then {_array append _patrolParams;} else {_array append _cargo;};
 		// Cargo Patrol Init
 		_array remoteExec ["fw_fnc_patrol",2];
+	};
 
-		// Patrol Script Params for Vehicle
-		_array2 = [leader _originalGroup];
-		_array2 append _patrolParams;
-		// Patrol Script init Vehicle
-		if (_v isKindOf "Air") then {
-			_pa = [_array2 select 1] call CBA_fnc_getArea;
-			[_originalGroup, _pa select 0, _pa select 1, 4, "MOVE", "SAFE", "YELLOW", "LIMITED", "COLUMN", "", [0,0,0]] call CBA_fnc_taskPatrol;
-		} else {
-			_array2 remoteExec ["fw_fnc_patrol",2];
-		};
+	// After the split loop — patrol the remaining cargo (always runs)
+	if (count units _ng > 0) then {
+		_array = [leader _ng];
+		if (count _cargo == 0) then {_array append _patrolParams;} else {_array append _cargo;};
+		_array remoteExec ["fw_fnc_patrol", 2];
+	};
+
+	// Patrol the vehicle group (always runs)
+	_array2 = [leader _originalGroup]; //leader might have changed, so grabbing again
+	_array2 append _patrolParams;
+	if (_v isKindOf "Air") then { //Loiter the Helo
+		private _pa = [_patrolParams select 0] call CBA_fnc_getArea;
+		private _paCenter = _pa select 0;
+		private _paRadius = selectMax [(_pa select 1),(_pa select 2),250]; // minimum 500m diameter
+
+		// Force loiter altitude to 150m AGL
+    	_v flyInHeight 150;
+
+		// Add LOITER waypoint at center
+		{deleteWaypoint _x} forEachReversed waypoints _originalGroup;
+		private _wp = _originalGroup addWaypoint [_paCenter, 0, 1];
+		_wp setWaypointType "LOITER";
+		_wp setWaypointLoiterType "CIRCLE";
+		_wp setWaypointLoiterRadius _paRadius;
+		_wp setWaypointBehaviour "SAFE";
+		_wp setWaypointSpeed "NORMAL";
+		_wp setWaypointCombatMode "WHITE";
+	} else {
+		_array2 remoteExec ["fw_fnc_patrol", 2];
 	};
 };

--- a/Framework Files/7R/Civ/fn_civBomber.sqf
+++ b/Framework Files/7R/Civ/fn_civBomber.sqf
@@ -50,7 +50,7 @@ _unit addItem "rhs_mag_rgd5";
 		if (count (waypoints _grp) > 1) then {
 			{
 				deleteWaypoint ((waypoints _grp) select 0);
-			} forEach waypoints _grp;
+			} forEachReversed waypoints _grp;
 		};
 		_unit doMove (position _target);
 		if (_unit distance2d _target < 25) then {

--- a/Framework Files/7R/Shared/fn_debrief.sqf
+++ b/Framework Files/7R/Shared/fn_debrief.sqf
@@ -12,7 +12,6 @@
 // Parameter Init
 params [["_noDelete",false]];
 
-
 // Exit when debrief already in progress
 if (phase == 9999) exitWith {
 	["DEBRIEF IN PROGRESS", 1.5] spawn ace_common_fnc_displayTextStructured;
@@ -20,6 +19,9 @@ if (phase == 9999) exitWith {
 
 // Message
 ["DEBRIEF STARTED", 1.5] spawn ace_common_fnc_displayTextStructured;
+
+// Save OCAP Recording
+["ocap_exportData", [SR_Side, "Operation Completed"]] call CBA_fnc_serverEvent;
 
 // Server only execute or HC if present
 if (isServer || (!hasInterface && !isDedicated)) then {

--- a/Framework Files/7R/Support/Exfil/fn_exfilAction.sqf
+++ b/Framework Files/7R/Support/Exfil/fn_exfilAction.sqf
@@ -15,16 +15,22 @@ params ["_vehicle",["_mode",0]];
 
 // Add Action to Helicopter
 _action = ["7R_EZA","Lift off","a3\ui_f\data\IGUI\Cfg\simpleTasks\types\heli_ca.paa",{
-	[2, (_this select 0), {
-		SR_HeliLiftoff = true;
-		publicVariable "SR_HeliLiftoff";
-	},{["","Action Canceled"] spawn sr_support_fnc_infoMessage;}, "Call for liftoff"] call ace_common_fnc_progressBar;
-},{!SR_HeliLiftoff},{},[],"",5,[false, true, false, false, false]] call ace_interact_menu_fnc_createAction;
+	_target setVariable ['fw_transport_takeoff_ready', true, true];
+},{!(_target getVariable ['fw_transport_takeoff_ready',false])},{},[],"",5,[false, true, false, false, false]] call ace_interact_menu_fnc_createAction;
 [_vehicle, 0, ["ACE_MainActions"], _action] call ace_interact_menu_fnc_addActionToObject;
 
 // Add Selfaction to Helicopter
-_selfAction = ["7R_EZA","Lift off","a3\ui_f\data\IGUI\Cfg\simpleTasks\types\heli_ca.paa",{
-	SR_HeliLiftoff = true;
-	publicVariable "SR_HeliLiftoff";
-},{!SR_HeliLiftoff},{},[],"",5,[false, true, false, false, false]] call ace_interact_menu_fnc_createAction;
+_selfAction = ["7R_EZSA","Lift off","a3\ui_f\data\IGUI\Cfg\simpleTasks\types\heli_ca.paa",
+{
+    // _this = [_target, _player, _params]
+    private _veh = (_this select 2) select 0;
+    _veh setVariable ['fw_transport_takeoff_ready', true, true];
+},
+{
+    private _veh = (_this select 2) select 0;
+    !(_veh getVariable ['fw_transport_takeoff_ready', false])
+},
+{}, [_vehicle], "", 5,  // <-- Pass _vehicle as custom param
+[false, true, false, false, false]
+] call ace_interact_menu_fnc_createAction;
 [_vehicle, 1, ["ACE_SelfActions"], _selfAction] call ace_interact_menu_fnc_addActionToObject;

--- a/Framework Files/7R/Support/Exfil/fn_exfilCall.sqf
+++ b/Framework Files/7R/Support/Exfil/fn_exfilCall.sqf
@@ -1,117 +1,225 @@
 /*
-	Parameters:
-		<-- Target Marker Name as String
-		<-- Spawn Marker Name as String
-		<-- Type of Helicopter as String
-		<-- Optional: Dropoff Marker as String  
-		<-- Caller as Object
+	File: fn_exfilCall.sqf
 
 	Description:
-	Handles AI based Exfiltration, spawning helicopter and picking up units. Optional drop off afterwards.
-	In case a dropoff marker is present after picking up units at the exfil, 
-	it will fly to the dropoff to unload all people before returning to his spawn to despawn.
-	
-	Example:
-	none
+	Server side script for exfil call from a player.
+
+	Parameter(s):
+	_ezMarker - pick up position [MARKER]
+	_spawnMarker - spawn poistion [MARKER]
+	_vehicleClass - class name of extraction helo [STRING]
+	_dropoff - Ending position [ARRAY]
+	_unit - The unit calling in the request [OBJECT]
+
+	Returns:
+	Function reached the end [BOOL]
+
+	Example(s):
+	[parameter] call fw_fnc_exfilCall
 */
 
-// Parameter Init
-params [["_targetMarker","EZ"],["_spawnMarker","STARTSPAWN"],["_type","RHS_CH_47F"],["_dropoffMarker","dropoff"],["_caller",objNull]];
+params [["_ezMarker","EZ"],["_spawnMarker","STARTSPAWN"],["_vehicleClass","RHS_CH_47F"],["_dropoffMarker","dropoff"],["_unit",objNull]];
 
-if !(isServer) exitWith{};
-
-private _spawn = markerPos _spawnMarker;
-private _target = markerPos _targetMarker;
-private _str = "";
-
-// Check if Target Marker exists if not exit with error msg
-if (_target isEqualto [0,0,0]) exitWith {
-	_str = "Exfil: No EZ designated";
-	[_str,_str] remoteExec ["sr_support_fnc_infoMessage", _caller];
+// Gather Positions from markers
+_ez = markerPos _ezMarker;
+_spawn_pos = markerPos _spawnMarker;
+_dropoff = markerPos _dropoffMarker;
+if (_dropoff isEqualTo [0,0,0]) then {
+	_dropoff = markerPos _spawnMarker;
 };
 
-// Check if Exfiltration is locked
-if (SR_HeliLiftoff) exitWith {
-	["Negative: Exfil not available. Other mission in progress.","Exfil: Currently busy"] remoteExec ["sr_support_fnc_infoMessage", _caller];
+// Check if Target Marker exists if not exit with error msg
+if (_ez isEqualto [0,0,0]) exitWith {
+	_str = "Exfil: No EZ designated";
+	[_str,_str] remoteExec ["sr_support_fnc_infoMessage", _unit];
 };
 
 // Check if Exfiltration is locked
 if (ExfilReady > CBA_MissionTime) exitWith {
 	private _timeLeft = ExfilReady - CBA_MissionTime;
-	[("Negative: Exfil not available. Try again in " + str(round _timeLeft) + " seconds."),("Exfil: Cooldown " + str(round _timeLeft) + " s")] remoteExec ["sr_support_fnc_infoMessage", _caller];
+	[("Negative: Exfil not available. Try again in " + str(round _timeLeft) + " seconds."),("Exfil: Cooldown " + str(round _timeLeft) + " s")] remoteExec ["sr_support_fnc_infoMessage", _unit];
 };
+
+// Log entry and Confirmation Message
+_str = "Exfil helicopter dispatched to Grid " + (mapGridPosition _ez) + ".";
+[_str,_str] remoteExec ["sr_support_fnc_infoMessage", _unit];
+["CombatLog", ["Support", _str]] call CBA_fnc_globalEvent; 
 
 // Set Ready & Liftoff
 ExfilReady = CBA_MissionTime + 90;
 publicVariable "ExfilReady";
 
-SR_HeliLiftoff = false;
-publicVariable "SR_HeliLiftoff";
+// Aircraft always come from the module's location
+private _distance = _ez distance2d _spawn_pos;
+private _speed = 150; // 150m/s
+private _setup_time = 45;
+private _wait_time = (_distance/_speed) + _setup_time;
 
-// Log entry and Confirmation Message
-_str = "Exfil Helicopter dispatched to Grid " + (mapGridPosition _target) + ".";
-[_str,_str] remoteExec ["sr_support_fnc_infoMessage", _caller];
-["CombatLog", ["Support", _str]] call CBA_fnc_globalEvent; 
+// clamp minimum value of _wait_time to 45s
+_wait_time = _wait_time max (45);
 
-// Spawning Helicopter
-private _heloArray = [_spawn, -90, _type, SR_Side] call bis_fnc_spawnVehicle;
-private _group = _heloArray select 2;
-private _helo = _heloArray select 0;
-
-// Disable AI in Parts
-[_group] spawn sr_support_fnc_supportAI;
-
-// Add Action for Lift Off
-[_helo] remoteExec ["fw_fnc_exfilAction", 0, true];
-
-// Clear Inventory of Helo
-clearweaponcargoGlobal _helo;  
-clearmagazinecargoGlobal _helo;  
-clearitemcargoGlobal _helo; 
-clearBackpackCargoGlobal _helo; 
-_helo addItemCargoGlobal ["SR_PAK", 10];
-
-// Set NOE Flight Altitude
-_helo flyInHeight 25;
-
-// Add Waypoints at EZ
-[_group, _target] spawn BIS_fnc_wpLand;
-
-waitUntil {sleep 0.5; (!([_helo] call fw_fnc_checkStatus) || (isTouchingGround _helo))};
-// Fail Safe
-sleep 3;
-if (!(isTouchingGround _helo)) then {
-
-	SR_HeliLiftoff = true;
-	publicVariable "SR_HeliLiftoff";
-};
-
-// Wait for Liftoff Command and lift off
-waitUntil {sleep 0.5; (!(alive _helo) || !(canMove _helo)) || (({alive _x} count units _group) < 1) || SR_HeliLiftoff};
-{deleteWaypoint _x} forEachReversed waypoints _group;
-private _holdPos = getPosATL _helo;
-_holdPos set [2, 150];
-[_group, _holdPos, "MOVE"] call fw_fnc_createWaypoint;
-
-// Check if Dropoff Marker exists if not exit with error msg
-if (markerPos _dropoffMarker isEqualto [0,0,0]) then {
-	_dropoffMarker = _spawnMarker;
-	_str = "Exfil: No dropoff designated, going to spawn";
-	["",_str] remoteExec ["sr_support_fnc_infoMessage", _caller];
-};
-
-// Assign recovered Variable
+fw_fnc_support_transport_function =
 {
-	_x setVariable ["SR_Recovered",true,true];
-}forEach crew _helo;
+	_this params ["_ez", "_dropoff", "_unit", "_vehicleClass", "_spawn_pos"];
 
-// Evaluate Dropoff
-if (!(markerPos _dropoffMarker isEqualTo [0,0,0]) && {({_x in allPlayers} count (crew _helo)) > 0}) then {
-	_wpDropoff = [_group, (markerPos _dropoffMarker), "TR UNLOAD"] call fw_fnc_createWaypoint;
+	_ez set [2, 0];
+	_dropoff set [2, 0];
+
+	private _dir = _ez getDir _spawn_pos;
+	private _dir_end = _dropoff getDir _spawn_pos;
+	private _spawn_position = _ez getPos [3000, _dir];
+	private _end_position = _ez getPos [3000, _dir_end];
+
+	_spawn_position set [2, 100];
+	_end_position set [2, 100];
+
+	private _vehicle_info = [_spawn_position, _dir, _vehicleClass, side _unit] call BIS_fnc_spawnVehicle;
+	_vehicle_info params ["_vehicle","_vehicle_crew","_vehicle_group"];
+	_vehicle setPosATL _spawn_position;
+
+	_vehicle lockDriver true;
+	_vehicle disableAi "TARGET";
+	_vehicle disableAi "AUTOTARGET";
+	_vehicle setCaptive true;
+	_vehicle_group allowFleeing 0;
+
+	_vehicle flyInHeight 100;
+
+	private _safe_start = _ez findEmptyPosition [0, 100, _vehicleClass];
+	if (count _safe_start <= 0) then
+	{
+		_safe_start = +_ez;
+	};
+	private _start_land_position = createVehicle ["Land_HelipadEmpty_F", _safe_start, [], 0, "CAN_COLLIDE"];
+
+	// Log entry and Confirmation Message
+	_str = "Exfil helicopter on final approach.";
+	[_str,_str] remoteExec ["sr_support_fnc_infoMessage", _unit];
+
+	private _waypoint_first_landing = _vehicle_group addWaypoint [_safe_start, 0];
+	_waypoint_first_landing setWaypointType "MOVE";
+	_waypoint_first_landing setWaypointBehaviour "CARELESS";
+	_waypoint_first_landing setWaypointCombatMode "BLUE";
+	_waypoint_first_landing setWaypointSpeed "NORMAL";
+	_waypoint_first_landing setWaypointCompletionRadius 50;
+	_waypoint_first_landing setWaypointStatements
+	[
+		"true",
+		"
+		private _vehicle = vehicle this;
+		if (local _vehicle) then
+		{
+			_vehicle land 'GET IN';
+		};
+		"
+	];
+
+	_vehicle flyInHeight 100;
+	
+	// Add Action to Helicopter
+	[_vehicle] remoteExec ["fw_fnc_exfilAction", 0, true];
+
+	private _timeout = time + 360;
+	waitUntil { (_vehicle getVariable ["fw_transport_takeoff_ready",false]) || time >= _timeout};
+
+	if (alive _vehicle && {alive (driver _vehicle)}) then
+	{
+
+		_vehicle land 'NONE';
+
+		private _end_land_position = createVehicle ["Land_HelipadEmpty_F", _dropoff, [], 0, "CAN_COLLIDE"];
+		private _waypoint_second_landing = _vehicle_group addWaypoint [_dropoff, 1];
+		_waypoint_second_landing setWaypointType "MOVE";
+		_waypoint_second_landing setWaypointBehaviour "CARELESS";
+		_waypoint_second_landing setWaypointCombatMode "BLUE";
+		_waypoint_second_landing setWaypointSpeed "NORMAL";
+		_waypoint_second_landing setWaypointCompletionRadius 50;
+		_waypoint_second_landing setWaypointStatements
+		[
+			"true",
+			"
+			private _vehicle = vehicle this;
+			if (local _vehicle) then
+			{
+				_vehicle setVariable ['fw_transport_change_lz', false, true];
+				_vehicle land 'GET OUT';
+			};
+			"
+		];
+
+		_vehicle flyInHeight 100;
+
+		_vehicle setVariable ['fw_transport_landing_waypoint', _waypoint_second_landing, true];
+		_vehicle setVariable ['fw_transport_landing_waypoint_helipad', _end_land_position, true];
+
+		waitUntil { ((_vehicle distance _end_land_position <= 50) && { ((getPos _vehicle)#2) <= 1 }) || !alive _vehicle || !alive (driver _vehicle) };
+
+		// Move players and their group out of the vehicle
+		{
+			private _unit = (_x#0);
+			if (isPlayer (leader group _unit) || isPlayer _unit) then
+			{
+				private _group = group _unit;
+				_group leaveVehicle _vehicle;
+				(units _group) apply
+				{
+					if (vehicle _x == _vehicle) then
+					{
+						moveOut _unit;
+					};
+				};
+			};
+			sleep 0.5;
+		} foreach (fullCrew _vehicle);
+
+		sleep 3;
+
+		waitUntil { ((fullCrew _vehicle) findif {isPlayer (_x#0)}) == -1 || !alive _vehicle || !alive (driver _vehicle) };
+
+		_vehicle land 'NONE';
+
+		private _waypoint_second_landing = _vehicle_group addWaypoint [_end_position, 1];
+		_waypoint_second_landing setWaypointType "MOVE";
+		_waypoint_second_landing setWaypointBehaviour "CARELESS";
+		_waypoint_second_landing setWaypointCombatMode "BLUE";
+		_waypoint_second_landing setWaypointSpeed "NORMAL";
+		_waypoint_second_landing setWaypointCompletionRadius 100;
+		_waypoint_second_landing setWaypointStatements
+		[
+			"true",
+			"
+			private _group = group this;
+			if (local _group) then
+			{
+				private _vehicle = vehicle this;
+				{ _vehicle deleteVehicleCrew _x } forEach crew _vehicle;
+				deleteVehicle _vehicle;
+				{ deleteVehicle _x } forEach units _group;
+				deleteGroup _group;
+			}
+			"
+		];
+
+		_vehicle flyInHeight 100;
+	};
 };
 
-// Final WP to fly off map and despawn
-sleep 3;
-private _wpEnd = [markerPos "STARTSPAWN", 2000, _helo getDir markerPos "STARTSPAWN"] call BIS_fnc_relPos;
-_wpEnd set [2, 50];	
-[_group, _wpEnd, "END"] call fw_fnc_createWaypoint;
+private _variable = "fw_support_transport_" + str (time+random 10000);
+missionNamespace setVariable [_variable, [_ez, _dropoff, _unit, _vehicleClass, _spawn_pos]];
+[
+		"itemAdd",
+		[
+				_variable,
+		compile format [
+		"
+			private _params = missionNamespace getVariable ['%1', []];
+			_params spawn fw_fnc_support_transport_function;
+			missionNamespace setVariable ['%1', nil];
+		", _variable],
+				_wait_time,
+				"seconds",
+				{ true },
+				{ false },
+				true
+		]
+] call BIS_fnc_loop;

--- a/Framework Files/7R/Support/Exfil/fn_exfilCall.sqf
+++ b/Framework Files/7R/Support/Exfil/fn_exfilCall.sqf
@@ -20,8 +20,8 @@ params [["_targetMarker","EZ"],["_spawnMarker","STARTSPAWN"],["_type","RHS_CH_47
 
 if !(isServer) exitWith{};
 
-_spawn = markerPos _spawnMarker;
-_target = markerPos _targetMarker;
+private _spawn = markerPos _spawnMarker;
+private _target = markerPos _targetMarker;
 private _str = "";
 
 // Check if Target Marker exists if not exit with error msg
@@ -54,9 +54,9 @@ _str = "Exfil Helicopter dispatched to Grid " + (mapGridPosition _target) + ".";
 ["CombatLog", ["Support", _str]] call CBA_fnc_globalEvent; 
 
 // Spawning Helicopter
-_helo = [_spawn, -90, _type, SR_Side] call bis_fnc_spawnVehicle;
-_group = _helo select 2;
-_helo = _helo select 0;
+private _heloArray = [_spawn, -90, _type, SR_Side] call bis_fnc_spawnVehicle;
+private _group = _heloArray select 2;
+private _helo = _heloArray select 0;
 
 // Disable AI in Parts
 [_group] spawn sr_support_fnc_supportAI;
@@ -71,10 +71,13 @@ clearitemcargoGlobal _helo;
 clearBackpackCargoGlobal _helo; 
 _helo addItemCargoGlobal ["SR_PAK", 10];
 
+// Set NOE Flight Altitude
+_helo flyInHeight 25;
+
 // Add Waypoints at EZ
 [_group, _target] spawn BIS_fnc_wpLand;
 
-waitUntil {(!([_helo] call fw_fnc_checkStatus) || (isTouchingGround _helo))};
+waitUntil {sleep 0.5; (!([_helo] call fw_fnc_checkStatus) || (isTouchingGround _helo))};
 // Fail Safe
 sleep 3;
 if (!(isTouchingGround _helo)) then {
@@ -84,27 +87,30 @@ if (!(isTouchingGround _helo)) then {
 };
 
 // Wait for Liftoff Command and lift off
-waitUntil {(!(alive _helo) || !(canMove _helo)) || (({alive _x} count units _group) < 1) || SR_HeliLiftoff};
+waitUntil {sleep 0.5; (!(alive _helo) || !(canMove _helo)) || (({alive _x} count units _group) < 1) || SR_HeliLiftoff};
 {deleteWaypoint _x} forEachReversed waypoints _group;
+private _holdPos = getPosATL _helo;
+_holdPos set [2, 150];
+[_group, _holdPos, "MOVE"] call fw_fnc_createWaypoint;
 
 // Check if Dropoff Marker exists if not exit with error msg
-if (_dropoffMarker isEqualto [0,0,0]) exitWith {
+if (markerPos _dropoffMarker isEqualto [0,0,0]) then {
 	_dropoffMarker = _spawnMarker;
 	_str = "Exfil: No dropoff designated, going to spawn";
-	[_str,_str] remoteExec ["sr_support_fnc_infoMessage", _caller];
+	["",_str] remoteExec ["sr_support_fnc_infoMessage", _caller];
 };
 
 // Assign recovered Variable
 {
 	_x setVariable ["SR_Recovered",true,true];
-}forEach assignedCargo _helo;
+}forEach crew _helo;
 
 // Evaluate Dropoff
-if (!(markerPos _dropoffMarker isEqualTo [0,0,0]) && {_x in allPlayers} count (crew _helo) > 0) then {
-	_wpDropoff = [_group, (markerPos _dropoffMarker), "TR UNLOAD"] spawn fw_fnc_createWaypoint;
+if (!(markerPos _dropoffMarker isEqualTo [0,0,0]) && {({_x in allPlayers} count (crew _helo)) > 0}) then {
+	_wpDropoff = [_group, (markerPos _dropoffMarker), "TR UNLOAD"] call fw_fnc_createWaypoint;
 };
 
-// Final WP to despawn
+// Final WP to fly off map and despawn
 sleep 3;
 private _wpEnd = [markerPos "STARTSPAWN", 2000, _helo getDir markerPos "STARTSPAWN"] call BIS_fnc_relPos;
 _wpEnd set [2, 50];	

--- a/Framework Files/7R/Templates/fn_spawnVehicleTemplate.sqf
+++ b/Framework Files/7R/Templates/fn_spawnVehicleTemplate.sqf
@@ -14,9 +14,10 @@
 */
 
 // Parameter Init
-params ["_leader","_marker","_speed","_patrolParams",["_cargo",[]],["_groupSize",4]];
+params ["_leader","_marker","_speed","_patrolParams",["_cargo",[]],["_groupSize",8],["_rtb",false]];
 private "_ins";
 _veh = vehicle _leader;
+_rtbPos = getPos _leader;
 
 // Damaged Eventhandler
 _index = (vehicle _leader) addEventHandler ["Dammaged",{(leader group driver (_this select 0)) setVariable ['dismount', true, true];}];
@@ -46,4 +47,4 @@ waitUntil {_leader getVariable ["dismount", false] || !alive _leader || !alive (
 
 // Remove Eventhandler
 (vehicle _leader) removeEventHandler ["Dammaged", _index];
-[_leader, _patrolParams, _cargo, _groupSize] spawn fw_fnc_dismountVehicle;
+[_leader, _patrolParams, _cargo, _groupSize, _rtb, _rtbPos] spawn fw_fnc_dismountVehicle;


### PR DESCRIPTION
- fn_exfilCall.sqf: Fixed broken condition, added sleep to waitUntil loops, fixed exitWith leaving no return path, and cleaned up private declarations and assignedCargo vs crew mismatch
- fn_createWaypoint.sqf: Fixed exclusive waypoint deletion skipping every other waypoint by switching forEach to forEachReversed
-  fn_dismountVehicle.sqf: Moved vehicle and remainder cargo patrol inits outside the while loop so they always fire, kept VCOM disabled on the vehicle group, and added proper LOITER behaviour for air vehicles with a minimum 500m radius and 150m AGL altitude
-  fn_debrief.sqf: Added functionality to save OCAP recordings